### PR TITLE
Add Bruch.io to mvn build process for zeppein-web

### DIFF
--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -77,35 +77,9 @@
           <executable>brunch build</executable>
         </configuration>
       </plugin>
-
-      <!-- did not work, results in exception :(
-           falling back to maven exec plugin
-      <plugin>
-        <groupId>org.mule.tools.javascript</groupId>
-        <artifactId>brunch-maven-plugin</artifactId>
-        <version>1.0-SNAPSHOT</version>
-        <configuration>
-            <sourceDirectory>src/main/webapp</sourceDirectory>
-        </configuration>
-      </plugin>
-      -->
     </plugins>
   </build>
-  <!--
-  <pluginRepositories>
-    <pluginRepository>
-        <id>mulesoft.snapshots</id>
-        <name>Mulesoft maven repository for brunch-maven-plugin dependecies</name>
-        <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots</url>
-        <releases>
-            <enabled>false</enabled>
-        </releases>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>        
-    </pluginRepository>
-  </pluginRepositories>
-  -->
+
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
First attempt was to use [brunch-maven-plugin](https://github.com/mulesoft/brunch-maven-plugin) but it failed (see SHA: 832d53a344162d6b5da54bfcbbb4acb7a257c37d)
Current one just use maven exec plugin, assuming dependencies from https://github.com/NFLabs/zeppelin/tree/master/zeppelin-web#build are already installed 

@Leemoonsoo Does that look good enough? This should work now. Can you verify?

```
mvn assemble:assemble
./bin/zeppein-demon.sh start
```
