### PR TITLE
Fix flickery test

### DIFF
--- a/zeppelin-zengine/src/test/java/com/nflabs/zeppelin/zengine/ShellExecStatementTest.java
+++ b/zeppelin-zengine/src/test/java/com/nflabs/zeppelin/zengine/ShellExecStatementTest.java
@@ -15,8 +15,8 @@ public class ShellExecStatementTest extends HiveTestService {
 
     public void setUp() throws Exception {
         super.setUp();
-//      Z z = new Z();
-//      z.configure();
+
+        Z.configure();
         
         // Configuration => Driver => Connection
         driver = new HiveZeppelinDriver(Z.getConf());


### PR DESCRIPTION
Zeppelin unittest is not stable. https://travis-ci.org/NFLabs/zeppelin
sometimes it success, sometimes it fails regardless of changes.

This pull request trying to stabilize the test. 
