### PR TITLE
Try to make JobManagerTest more predictable

### DIFF
--- a/zeppelin-server/src/main/java/com/nflabs/zeppelin/scheduler/Job.java
+++ b/zeppelin-server/src/main/java/com/nflabs/zeppelin/scheduler/Job.java
@@ -52,10 +52,17 @@ public abstract class Job {
 		this.listener = listener;
 	}
 	
+	public JobListener getListener(){
+		return listener;
+	}
+	
 	public void setStatus(Status status){
 		if(this.status==status) return;
+		Status before = this.status;
+		Status after = status;
+		if(listener!=null) listener.beforeStatusChange(this, before, after);
 		this.status = status;
-		if(listener!=null) listener.statusChange(this);
+		if(listener!=null) listener.afterStatusChange(this, before, after);
 	}
 	
 	public boolean isTerminated(){
@@ -98,6 +105,10 @@ public abstract class Job {
 		return exception;
 	}
 	
+	protected void setException(Throwable t){
+		exception = t;
+	}
+	
 	public Object getReturn(){
 		return result;
 	}
@@ -133,6 +144,4 @@ public abstract class Job {
 	public Date getDateFinished() {
 		return dateFinished;
 	}
-	
-	
 }

--- a/zeppelin-server/src/main/java/com/nflabs/zeppelin/scheduler/JobListener.java
+++ b/zeppelin-server/src/main/java/com/nflabs/zeppelin/scheduler/JobListener.java
@@ -1,5 +1,6 @@
 package com.nflabs.zeppelin.scheduler;
 
 public interface JobListener {
-	public void statusChange(Job job);
+	public void beforeStatusChange(Job job, Job.Status before, Job.Status after);
+	public void afterStatusChange(Job job, Job.Status before, Job.Status after);
 }

--- a/zeppelin-server/src/main/java/com/nflabs/zeppelin/server/ZQLJob.java
+++ b/zeppelin-server/src/main/java/com/nflabs/zeppelin/server/ZQLJob.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.nflabs.zeppelin.driver.ZeppelinConnection;
 import com.nflabs.zeppelin.driver.ZeppelinDriverException;
 import com.nflabs.zeppelin.result.Result;
@@ -34,6 +36,23 @@ public class ZQLJob extends Job{
 	
 	private Logger logger(){
 		return LoggerFactory.getLogger(ZQLJob.class);
+	}
+	
+	public ZQLJob clone(){
+		// clone object using gson
+		GsonBuilder gsonBuilder = new GsonBuilder();
+		gsonBuilder.setPrettyPrinting();
+		gsonBuilder.registerTypeAdapter(Z.class, new ZAdapter());
+
+		Gson gson = gsonBuilder.create();
+		String jsonstr = gson.toJson(this);
+		ZQLJob job = gson.fromJson(jsonstr, ZQLJob.class);
+		
+		// set transient values
+		job.conn = conn;
+		job.setListener(getListener());
+		job.setException(getException());
+		return job;
 	}
 	
 	public void setZQL(String zql){

--- a/zeppelin-server/src/test/java/com/nflabs/zeppelin/server/ZQLJobManagerTest.java
+++ b/zeppelin-server/src/test/java/com/nflabs/zeppelin/server/ZQLJobManagerTest.java
@@ -15,11 +15,11 @@ import com.nflabs.zeppelin.scheduler.Job.Status;
 import com.nflabs.zeppelin.scheduler.SchedulerFactory;
 import com.nflabs.zeppelin.zengine.Z;
 
-public class ZQLSessionManagerTest extends TestCase {
+public class ZQLJobManagerTest extends TestCase {
 
 	private File tmpDir;
 	private SchedulerFactory schedulerFactory;
-	private ZQLJobManager sm;
+	private ZQLJobManager jm;
 	private File dataDir;
 
 
@@ -35,7 +35,7 @@ public class ZQLSessionManagerTest extends TestCase {
 
 		this.schedulerFactory = new SchedulerFactory();
 
-		this.sm = new ZQLJobManager(schedulerFactory.createOrGetFIFOScheduler("analyze"), Z.fs(), Z.getConf().getString(ConfVars.ZEPPELIN_JOB_DIR));
+		this.jm = new ZQLJobManager(schedulerFactory.createOrGetFIFOScheduler("analyze"), Z.fs(), Z.getConf().getString(ConfVars.ZEPPELIN_JOB_DIR));
 	}
 
 	protected void tearDown() throws Exception {
@@ -58,110 +58,110 @@ public class ZQLSessionManagerTest extends TestCase {
 
 	public void testCRUD() {
 		// Create
-		ZQLJob sess = sm.create();
+		ZQLJob sess = jm.create();
 		assertNotNull(sess);
 		
 		// List
-		assertEquals(1, sm.list().size());
+		assertEquals(1, jm.list().size());
 		
 		// Update
-		sm.setZql(sess.getId(), "show tables");
+		jm.setZql(sess.getId(), "show tables");
 		
 		// Get
-		assertEquals("show tables", sm.get(sess.getId()).getZQL());
+		assertEquals("show tables", jm.get(sess.getId()).getZQL());
 		
 		// Delete
-		sm.delete(sess.getId());
-		assertNull(sm.get(sess.getId()));
+		jm.delete(sess.getId());
+		assertNull(jm.get(sess.getId()));
 		
 		// List
-		assertEquals(0, sm.list().size());
+		assertEquals(0, jm.list().size());
 	}
 	
 	public void testRun() throws InterruptedException, SchedulerException{
 		// Create
-		ZQLJob sess = sm.create();
-		sm.setZql(sess.getId(), "show tables");
+		ZQLJob sess = jm.create();
+		jm.setZql(sess.getId(), "show tables");
 		
 		// check if new session manager read
-		sm = new ZQLJobManager(schedulerFactory.createOrGetFIFOScheduler("analyze"), Z.fs(), Z.getConf().getString(ConfVars.ZEPPELIN_JOB_DIR));
+		jm = new ZQLJobManager(schedulerFactory.createOrGetFIFOScheduler("analyze"), Z.fs(), Z.getConf().getString(ConfVars.ZEPPELIN_JOB_DIR));
 		
 		// run the session
-		sm.run(sess.getId());
+		jm.run(sess.getId());
 		
-		while(sm.get(sess.getId()).getStatus()!=Status.FINISHED){
+		while(jm.get(sess.getId()).getStatus()!=Status.FINISHED){
 			Thread.sleep(300);
 		}
 		
-		assertEquals(Status.FINISHED, sm.get(sess.getId()).getStatus());
+		assertEquals(Status.FINISHED, jm.get(sess.getId()).getStatus());
 		
 		// check if history is made
-		assertEquals(sess.getId(), sm.getHistory(sess.getId(), sm.listHistory(sess.getId()).firstKey()).getId());
+		assertEquals(sess.getId(), jm.getHistory(sess.getId(), jm.listHistory(sess.getId()).firstKey()).getId());
 		
 		// run session again
-		sm.run(sess.getId());
+		jm.run(sess.getId());
 
-		while(sm.get(sess.getId()).getStatus()!=Status.FINISHED){ // wait for finish
+		while(jm.get(sess.getId()).getStatus()!=Status.FINISHED){ // wait for finish
 			Thread.sleep(300);
 		}
 
 		// another history made
-		assertEquals(2, sm.listHistory(sess.getId()).size());
+		assertEquals(2, jm.listHistory(sess.getId()).size());
 		
 		// remove a history
-		sm.deleteHistory(sess.getId(), sm.listHistory(sess.getId()).firstKey());
-		assertEquals(1, sm.listHistory(sess.getId()).size());
+		jm.deleteHistory(sess.getId(), jm.listHistory(sess.getId()).firstKey());
+		assertEquals(1, jm.listHistory(sess.getId()).size());
 		
 		// remove whole history
-		sm.deleteHistory(sess.getId());
-		assertEquals(0, sm.listHistory(sess.getId()).size());
+		jm.deleteHistory(sess.getId());
+		assertEquals(0, jm.listHistory(sess.getId()).size());
 		
 	}
 	
 	@SuppressWarnings("unchecked")
     public void testSerializePlan() throws InterruptedException{
 		// Create
-		ZQLJob sess = sm.create();
-		sm.setZql(sess.getId(), "!echo hello;!echo world");
+		ZQLJob sess = jm.create();
+		jm.setZql(sess.getId(), "!echo hello;!echo world");
 
 		// run the session
-		sm.run(sess.getId());
+		jm.run(sess.getId());
 		
 
-		while(sm.get(sess.getId()).getStatus()!=Status.FINISHED){
+		while(jm.get(sess.getId()).getStatus()!=Status.FINISHED){
 			Thread.sleep(300);
 		}
 		
 		assertEquals(2, ((LinkedList<Result>)sess.getReturn()).size());
-		List<Result> ret = (List<Result>) sm.get(sess.getId()).getReturn();
+		List<Result> ret = (List<Result>) jm.get(sess.getId()).getReturn();
 		assertEquals(2, ret.size());
 		
 	}
 	
 	@SuppressWarnings("unchecked")
 	public void testCron() throws InterruptedException{
-		ZQLJob sess = sm.create();
-		sm.setZql(sess.getId(), "!echo 'hello world'");
-		sm.setCron(sess.getId(), "0/1 * * * * ?");
+		ZQLJob sess = jm.create();
+		jm.setZql(sess.getId(), "!echo 'hello world'");
+		jm.setCron(sess.getId(), "0/1 * * * * ?");
 
-		while (sm.get(sess.getId()).getStatus()!=Status.FINISHED){
+		while (jm.get(sess.getId()).getStatus()!=Status.FINISHED){
 			Thread.sleep(300);
 		}
 		
-		List<Result> ret = (List<Result>) sm.get(sess.getId()).getReturn();
+		List<Result> ret = (List<Result>) jm.get(sess.getId()).getReturn();
 		assertEquals("hello world", ret.get(0).getRows().get(0)[0]);
 
-		Date firstDateFinished = sm.get(sess.getId()).getDateFinished();
+		Date firstDateFinished = jm.get(sess.getId()).getDateFinished();
 		
 		// wait for second run
-		while (sm.get(sess.getId()).getDateFinished().getTime()==firstDateFinished.getTime()){
+		while (jm.get(sess.getId()).getDateFinished().getTime()==firstDateFinished.getTime()){
 			Thread.sleep(300);
 		}
 		
-		ret = (List<Result>) sm.get(sess.getId()).getReturn();
+		ret = (List<Result>) jm.get(sess.getId()).getReturn();
 		assertEquals("hello world", ret.get(0).getRows().get(0)[0]);		
 		
-		sm.delete(sess.getId());
+		jm.delete(sess.getId());
 	}
 
 }


### PR DESCRIPTION
Session status is changed like READY -> RUNNING -> FINISHED
after each status change, statusChange(job) callback is called.
and inside of statusChange callback, jobManager implement session persistence and history creation.
It means there will be a moment, after session become FINISHED status and session persisted and history created.
If test wait for status be FINISHED and looking for history then there's chance to history not exist for a certain time.

This pull request change statusChange() to beforeStatusChange() and afterStatusChange(). 
and all persistent, history creation is done inside of beforeStatusChange().
This change will make sure session persistence and making history done before status changed to FINISHED.
