### PR TITLE
ZEPPELIN-81 handle port number changes

### DIFF
--- a/zeppelin-web/app/zeppelin.js
+++ b/zeppelin-web/app/zeppelin.js
@@ -16,11 +16,11 @@ function Zeppelin(arg){
     }
 
     this.getBaseURL = function(){
-        return "http://"+window.location.host.split(":")[0]+":8080";
+        return "http://"+window.location.host;
     }
     
     this.getRestURL = function(){
-        return "http://"+window.location.host.split(":")[0]+":8080/cxf/zeppelin";
+        return "http://"+window.location.host+"/cxf/zeppelin";
     }
     
     this.isDevMode = function(){

--- a/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/conf/ZeppelinConfiguration.java
@@ -79,7 +79,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
 		if(properties==null || properties.size()==0) return d;
 		for(ConfigurationNode p : properties){
 			if(p.getChildren("name")!=null && p.getChildren("name").size()>0 && name.equals(p.getChildren("name").get(0).getValue())){
-				return (Integer) p.getChildren("value").get(0).getValue();
+				return Integer.parseInt((String) p.getChildren("value").get(0).getValue());
 			}
 		}		
 		return d;
@@ -90,7 +90,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
 		if(properties==null || properties.size()==0) return d;
 		for(ConfigurationNode p : properties){
 			if(p.getChildren("name")!=null && p.getChildren("name").size()>0 && name.equals(p.getChildren("name").get(0).getValue())){
-				return (Long) p.getChildren("value").get(0).getValue();
+				return Long.parseLong((String) p.getChildren("value").get(0).getValue());
 			}
 		}		
 		return d;
@@ -101,7 +101,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
 		if(properties==null || properties.size()==0) return d;
 		for(ConfigurationNode p : properties){
 			if(p.getChildren("name")!=null && p.getChildren("name").size()>0 && name.equals(p.getChildren("name").get(0).getValue())){
-				return (Float) p.getChildren("value").get(0).getValue();
+				return Float.parseFloat((String) p.getChildren("value").get(0).getValue());
 			}
 		}		
 		return d;
@@ -112,7 +112,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
 		if(properties==null || properties.size()==0) return d;
 		for(ConfigurationNode p : properties){
 			if(p.getChildren("name")!=null && p.getChildren("name").size()>0 && name.equals(p.getChildren("name").get(0).getValue())){
-				return (Boolean) p.getChildren("value").get(0).getValue();
+				return Boolean.parseBoolean((String) p.getChildren("value").get(0).getValue());
 			}
 		}		
 		return d;


### PR DESCRIPTION
Described this bugs [ZEPPELIN-81](https://zeppelin-project.atlassian.net/browse/ZEPPELIN-81).

Two things was wrong. 
1. ZeppelinConfiguration class couldn't handle numeric type.
2. Zeppelin-web has hardcoded port number 8080

This PR includes fix for 1,2.
