### PR TITLE
npm install failed

### DIFF
--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -56,7 +56,7 @@
           </execution>
 
           <execution>
-            <!-- This is workaround for looking for wrong registry when npm installing ansi-color package -->
+            <!-- This is workaround for looking for wrong registry when npm installing ansi-color package, when brunch bringing ansi-color as a dependency -->
             <id>npm install ansi-color</id>
             <phase>generate-sources</phase>
             <goals>


### PR DESCRIPTION
From some moment, 'npm install' command failed.
it is looking for wrong domain http://packages:5984/  
The same issue described in many different projects. for example https://github.com/npm/npm/issues/362
