### PR TITLE
ZEPPELIN-93 include hive-contrib as a runtime dependency

### DIFF
--- a/zeppelin-driver-hive11/pom.xml
+++ b/zeppelin-driver-hive11/pom.xml
@@ -118,6 +118,7 @@
       <artifactId>hive-contrib</artifactId>
       <version>${hive.version}</version>
       <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
     
     <!-- hive-jdbc, hive-test dependencies have transitive dependency to derby. in different version.


### PR DESCRIPTION
include hive-contrib as a runtime dependency.
see [ZEPPELIN-93](https://zeppelin-project.atlassian.net/browse/ZEPPELIN-93) for more detail
