### PR TITLE
ZEPPELIN-99 disable redirect statement

### DIFF
--- a/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/zengine/stmt/ZQL.java
+++ b/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/zengine/stmt/ZQL.java
@@ -37,7 +37,7 @@ import com.nflabs.zeppelin.zengine.stmt.AnnotationStatement.COMMAND;
  *
  */
 public class ZQL {
-	String [] op = new String[]{";", "|", ">>", ">"};
+	String [] op = new String[]{";", "|" /* Disable redirect. see ZEPPELIN-99, ">>", ">" */};
 	StringBuilder sb = new StringBuilder();
 
 	public ZQL(){
@@ -183,6 +183,7 @@ public class ZQL {
 			}
 			
 			// Current operator is redirect
+			/* Disable redirect. see ZEPPELIN-99
 			if(op[2].equals(currentOp)){ // redirect append
 				throw new ZQLException("redirection (append) not implemented");
 			} else if(op[3].equals(currentOp)){ // redirect overwrite
@@ -196,6 +197,7 @@ public class ZQL {
 					throw new ZQLException("Can not redirect empty");
 				}				
 			}
+			*/
 			
 			// check if it is Annotation
 			if(stmt.startsWith("@")){

--- a/zeppelin-zengine/src/test/java/com/nflabs/zeppelin/zengine/stmt/ZQLTest.java
+++ b/zeppelin-zengine/src/test/java/com/nflabs/zeppelin/zengine/stmt/ZQLTest.java
@@ -89,15 +89,15 @@ public class ZQLTest extends TestCase {
 		}
 	}
 	
-	public void testRedirection() throws ZException, ZQLException{
+	public void testGtLt() throws ZException, ZQLException{
 		ZQL zql = new ZQL();
-		zql.append("select * from bank limit 10 > summary");
+		zql.append("select * from bank where age > 10 and age < 20");
 		List<Z> plan = zql.compile();
 		
 		assertEquals(1, plan.size());
-		assertEquals("select * from bank limit 10", plan.get(0).getQuery());
+		assertEquals("select * from bank where age > 10 and age < 20", plan.get(0).getQuery());
 	}
-
+	
 	public void testLstmtSimple() throws ZException, ZQLException{
 		ZQL zql = new ZQL("test");
 		List<Z> zList = zql.compile();


### PR DESCRIPTION
ZQL parser is not handling redirect operator in smart way. I think it's better to turn off redirect statement until we get better ZQL parser. issue addressed in [ZEPPELIN-99](https://zeppelin-project.atlassian.net/browse/ZEPPELIN-99).
