### PR TITLE
ZEPPELIN-98 share ERB tempaltes local variables between statments

### DIFF
--- a/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/zengine/stmt/L.java
+++ b/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/zengine/stmt/L.java
@@ -101,6 +101,11 @@ public class L extends Q {
 	public String getQuery() throws ZException {
 		initialize();		
 		
+		if(hasPrev()){
+			// purpose of calling is evaluating erb. because it need to share the same local variable context
+			prev().getQuery();
+		}
+
 		if(erbFile==null){
 			return null;
 		}

--- a/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/zengine/stmt/ZQL.java
+++ b/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/zengine/stmt/ZQL.java
@@ -6,23 +6,17 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URI;
-import java.net.URLClassLoader;
 import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.nflabs.zeppelin.driver.LazyConnection;
 import com.nflabs.zeppelin.driver.ZeppelinConnection;
-import com.nflabs.zeppelin.driver.ZeppelinDriver;
 import com.nflabs.zeppelin.util.Util;
 import com.nflabs.zeppelin.zengine.ZException;
 import com.nflabs.zeppelin.zengine.ZPlan;
 import com.nflabs.zeppelin.zengine.ZQLException;
-import com.nflabs.zeppelin.zengine.Zengine;
 import com.nflabs.zeppelin.zengine.stmt.AnnotationStatement.ANNOTATION;
 import com.nflabs.zeppelin.zengine.stmt.AnnotationStatement.COMMAND;
 /**
@@ -39,6 +33,7 @@ import com.nflabs.zeppelin.zengine.stmt.AnnotationStatement.COMMAND;
 public class ZQL {
 	String [] op = new String[]{";", "|", ">>", ">"};
 	StringBuilder sb = new StringBuilder();
+	Map<String, Object> binding = new HashMap<String, Object>();
 
 	public ZQL(){
 	}
@@ -244,6 +239,7 @@ public class ZQL {
 				Q q;
 				try {
 					q = new Q(stmt);
+					q.withErbBinding(binding);
 				} catch (ZException e) {
 					throw new ZQLException(e);
 				}


### PR DESCRIPTION
[ZEPPELIN-98](https://zeppelin-project.atlassian.net/browse/ZEPPELIN-98)

Zeppelin support erb templating for it's query, but erb templates local variable is not shared between statements.

This PR make share local variable between statements.
