### PR TITLE
ZEPPELIN-104 Allow multiline args

### DIFF
--- a/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/zengine/stmt/ZQL.java
+++ b/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/zengine/stmt/ZQL.java
@@ -276,7 +276,7 @@ public class ZQL {
 	 * libName(param1=value1, param2=value2, ...)
 	 * libName(param1=value1, param2=value2, ...) args
 	 */
-	static final Pattern LPattern = Pattern.compile("([^ ()]*)\\s*([(][^)]*[)])?\\s*(.*)");
+	static final Pattern LPattern = Pattern.compile("([^ ()]*)\\s*([(][^)]*[)])?\\s*(.*)", Pattern.DOTALL);
 	private L loadL(String stmt, ZeppelinConnection currentConnection) throws ZException{
 		Matcher m = LPattern.matcher(stmt);
 		

--- a/zeppelin-zengine/src/test/java/com/nflabs/zeppelin/zengine/stmt/ZQLTest.java
+++ b/zeppelin-zengine/src/test/java/com/nflabs/zeppelin/zengine/stmt/ZQLTest.java
@@ -40,7 +40,7 @@ public class ZQLTest extends TestCase {
 		UtilsForTests.delete(new File("/tmp/warehouse"));
 		System.setProperty(ConfVars.ZEPPELIN_ZAN_LOCAL_REPO.getVarName(), tmpDirPath);
 
-		String q1 = "select * from (<%= z."+Q.INPUT_VAR_NAME+" %>) a limit <%= z.param('limit') %>\n";
+		String q1 = "select * from (<%= z."+Q.INPUT_VAR_NAME+" %>) a limit <%= z.param('limit') %><%= z.arg%>\n";
 		// erb library with resource
 		new File(tmpDirPath + "/test").mkdir();
 		UtilsForTests.createFileWithContent(tmpDirPath + "/test/zql.erb", q1);
@@ -105,6 +105,15 @@ public class ZQLTest extends TestCase {
 		assertEquals(1, zList.size());
 		Z q = zList.get(0);
 		assertEquals("select * from () a limit ", q.getQuery());
+		q.release();
+	}
+	
+	public void testLstmtMultilineArgs() throws ZException, ZQLException{
+		ZQL zql = new ZQL("test hello\nworld");
+		List<Z> zList = zql.compile();
+		assertEquals(1, zList.size());
+		Z q = zList.get(0);
+		assertEquals("select * from () a limit hello\nworld", q.getQuery());
 		q.release();
 	}
 	


### PR DESCRIPTION
Allow library call with multiline arguments. issue described [ZEPPELIN-104](https://zeppelin-project.atlassian.net/browse/ZEPPELIN-104)

This pull request includes fix and unittest.
