### PR TITLE
ZEPPELIN-105 do not execute empty line

### DIFF
--- a/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/zengine/stmt/Z.java
+++ b/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/zengine/stmt/Z.java
@@ -3,6 +3,7 @@ package com.nflabs.zeppelin.zengine.stmt;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -313,14 +314,23 @@ public abstract class Z {
 		String query = getQuery();
 
 		if (query!=null) {
-			String[] queries = Util.split(query, ';');
-			for (int i=0; i<queries.length-1; i++){//all except last one
-			    q = queries[i];
+			String[] querySplit = Util.split(query, ';');
+			List<String> queries = new LinkedList<String>();
+			for (int i = 0; i < querySplit.length; i++) {
+				String qs = querySplit[i];
+				if(qs==null) continue;
+				qs = qs.trim();
+				if(qs.length()==0) continue;
+				queries.add(qs);
+			}
+
+			for (int i=0; i<queries.size()-1; i++){//all except last one
+			    q = queries.get(i);
 			    lastQueryResult = executeQuery(q);
 			}
 			
-			if (queries.length > 0) {//the last query
-	            q = queries[queries.length-1];
+			if (queries.size() > 0) {//the last query
+	            q = queries.get(queries.size()-1);
 	            if (isUnNamed()) {	
 	                lastQueryResult = executeQuery(q);
 	            } else {

--- a/zeppelin-zengine/src/test/java/com/nflabs/zeppelin/zengine/stmt/QTest.java
+++ b/zeppelin-zengine/src/test/java/com/nflabs/zeppelin/zengine/stmt/QTest.java
@@ -66,6 +66,14 @@ public class QTest extends TestCase {
         assertEquals("hello", infos.get("fieldname").getDefaultValue());
     }
     
+	public void testMultiEmptyLines() throws ZException, IOException, ResultDataException {
+		drv.queries.put("select count(*) from test;", new Result(0, new String[] { "1" }));
+		drv.queries.put("show tables", new Result(0, new String[] { "2" }));
+		Result r = new Q("select count(*) from test;\nshow tables;\n\n").execute(conn).result();
+		assertEquals(1, r.getRows().size());
+		assertEquals("2", r.getRows().get(0)[0]);
+	}
+
     public void testRunQuery() throws ZException {
         //given
         //  zengine.set(mock(Hive) with table 2 rows in table "test")


### PR DESCRIPTION
When zql.erb in zeppelin library has multiple empty lines, execute() trying to run multiple empty lines as a 'null' query.

issue described [ZEPPELIN-105](https://zeppelin-project.atlassian.net/browse/ZEPPELIN-105)

This pull request has implementation of unittest for this bug, and fixed code.
