### PR TITLE
ZEPPELIN-148 run all paragraph

### DIFF
--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -326,6 +326,7 @@ Alternatively you can set the class path throuh nsc.Settings.classpath.
 	 * Interpret a single line
 	 */
 	public InterpreterResult interpret(String line){
+		if(line==null) line = "";
 		return interpret(line.split("\n"));
 	}
 	

--- a/zeppelin-server/src/main/java/com/nflabs/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/com/nflabs/zeppelin/socket/NotebookServer.java
@@ -341,14 +341,15 @@ public class NotebookServer extends WebSocketServer {
     }
     final Note note = notebook.getNote(getOpenNoteId(conn));
     Paragraph p = note.getParagraph(paragraphId);
-    p.setText((String) fromMessage.get("paragraph"));
+    String text = (String) fromMessage.get("paragraph");
+    p.setText(text);
     Map<String, Object> params = (Map<String, Object>) fromMessage.get("params");
     p.settings.setParams(params);
     Map<String, Object> config = (Map<String, Object>) fromMessage.get("config");
     p.setConfig(config);
-
+    
     // if it's an last pargraph, let's add new one
-    if (note.getLastParagraph().getId().equals(p.getId())) {
+    if (text!=null && text.length()>0 && note.getLastParagraph().getId().equals(p.getId())) {
       note.addParagraph();
       broadcastNote(note.id(), new Message(OP.NOTE).put("note", note));
     }

--- a/zeppelin-web/app/scripts/controllers/notebook.js
+++ b/zeppelin-web/app/scripts/controllers/notebook.js
@@ -44,6 +44,27 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       $location.path('/#');
     }
   };
+
+  $scope.runNote = function(noteId) {
+    var result = confirm('Run all paragraphs?');
+    if (result) {
+      for (var i=0; i<$scope.note.paragraphs.length; i++) {
+        $rootScope.$emit('runParagraph', $scope.note.paragraphs[i].id);
+      }
+    }
+  };
+
+  $scope.isNoteRunning = function() {
+    var running = false;
+    if(!$scope.note) return false;
+    for (var i=0; i<$scope.note.paragraphs.length; i++) {
+      if ( $scope.note.paragraphs[i].status === "PENDING" || $scope.note.paragraphs[i].status === "RUNNING") {
+        running = true;
+        break;
+      }
+    }
+    return running;
+  };
   
   /** Update the note name */
   $scope.sendNewName = function() {

--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -379,6 +379,12 @@ angular.module('zeppelinWebApp')
     }
   });
 
+  $rootScope.$on('runParagraph', function(event, paragraphId){
+    if ($scope.paragraph.id === paragraphId) {
+        $scope.runParagraph($scope.editor.getValue());
+    }
+  });
+
   $scope.getResultType = function(paragraph){
     var pdata = (paragraph) ? paragraph : $scope.paragraph;
     if (pdata.result && pdata.result.type) {

--- a/zeppelin-web/app/styles/notebook.css
+++ b/zeppelin-web/app/styles/notebook.css
@@ -120,6 +120,16 @@
   transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
 }
 
+.noteAction:hover span {
+    display: inline-block;
+    visibility: visible;
+}
+
+.noteAction span {
+    display: inline-block;
+    visibility: hidden;
+}
+
 .form-control-static2 {
   padding-top: 7px;
   font-size: 24px;

--- a/zeppelin-web/app/views/notebooks.html
+++ b/zeppelin-web/app/views/notebooks.html
@@ -21,6 +21,9 @@ limitations under the License.
          <p class="form-control-static2" ng-click="showEditor = true" ng-show="!showEditor">{{note.name || 'Note ' + note.id}}</p>
       <span class="label">
         <button style="margin-bottom: 9px;" type="button" class="btn btn-default btn-xs" ng-click="removeNote(note.id)">remove <span class="fa fa-trash"></span></button>
+        <button style="margin-bottom: 9px;" type="button" class="btn btn-default btn-xs" 
+                ng-click="runNote(note.id)"
+                ng-if="!isNoteRunning()">run <span class="fa fa-play"></span></button>
       </span>
     </h3>
   </div>

--- a/zeppelin-web/app/views/paragraph.html
+++ b/zeppelin-web/app/views/paragraph.html
@@ -24,23 +24,23 @@ limitations under the License.
     
 
     <!-- Editor handler -->
-    <span class="fa fa-compress" style="cursor:pointer" tooltip-placement="left" tooltip="Hide editor"
+    <span class="fa fa-compress" style="cursor:pointer" tooltip-placement="top" tooltip="Hide editor"
           ng-click="closeEditor()"
           ng-show="!paragraph.config.editorHide && !paragraph.config.hide"></span>
-    <span class="fa fa-expand" style="cursor:pointer" tooltip-placement="left" tooltip="Show editor"
+    <span class="fa fa-expand" style="cursor:pointer" tooltip-placement="top" tooltip="Show editor"
           ng-click="openEditor()"
           ng-show="paragraph.config.editorHide && !paragraph.config.hide"></span>
     
     <!-- paragraph handler -->
-    <span class="fa fa-sort-desc" style="cursor:pointer" tooltip-placement="left" tooltip="Hide this Paragraph"
+    <span class="fa fa-sort-desc" style="cursor:pointer" tooltip-placement="top" tooltip="Hide this Paragraph"
           ng-click="closeParagraph()"
           ng-show="!paragraph.config.hide"></span> 
-    <span class="fa fa-sort-up" style="cursor:pointer" tooltip-placement="left" tooltip="Show this Paragraph"
+    <span class="fa fa-sort-up" style="cursor:pointer" tooltip-placement="top" tooltip="Show this Paragraph"
           ng-click="openParagraph()"
           ng-show="paragraph.config.hide"></span>
     
     <!-- remove paragraph -->
-    <span class="fa fa-times" style="cursor:pointer" tooltip-placement="left" tooltip="Remove this Paragraph"
+    <span class="fa fa-times" style="cursor:pointer" tooltip-placement="top" tooltip="Remove this Paragraph"
           ng-click="removeParagraph()"></span>
   </div>
   <div ng-show="!paragraph.config.hide">

--- a/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/notebook/Note.java
@@ -152,12 +152,13 @@ public class Note implements Serializable, JobListener {
 	
 	/**
 	 * Run all paragraphs sequentially
+	 * @param jobListener 
 	 */
-	public void runAll(){
+	public void runAll(JobListener jobListener){
 		synchronized(paragraphs){
 			for (Paragraph p : paragraphs) {
 				p.setNoteReplLoader(replLoader);
-				p.setListener(this);
+				p.setListener(jobListener);
 				Scheduler scheduler = replLoader.getScheduler(p.getRequiredReplName());		
 				scheduler.submit(p);
 			}


### PR DESCRIPTION
[ZEPPELIN-148](https://zeppelin-project.atlassian.net/browse/ZEPPELIN-148)
Button for run all paragraphs in notebook at once.

Here's how implemented
- RIght of notebook's title, there were 'remove' button. now, 'Run'  button is added
- 'Remove', 'Run' button is now only show when mouse hover notebook title.
- 'Run' button only shows when no paragraph in notebook running / pending
- 'Run' button actually invoke multiple paragraph run request from client-side. rather than server side runAll api invoke. for applying client's local update.

This is ready to merge
