### PR TITLE
Catching and displaying more error on SparkSql

### DIFF
--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
@@ -70,12 +70,14 @@ public class SparkSqlInterpreter extends Interpreter {
 	public InterpreterResult interpret(String st) {
 		SQLContext sqlc = getSparkInterpreter().getSQLContext();
 		SparkContext sc = sqlc.sparkContext();
-		sc.setJobGroup(jobGroup, "Zeppelin", false);	
-		SchemaRDD rdd = sqlc.sql(st);
+		sc.setJobGroup(jobGroup, "Zeppelin", false);
+		SchemaRDD rdd;
 		Row[] rows = null;
 		try {
+			rdd = sqlc.sql(st);
 			rows = rdd.take(10000);
 		} catch(Exception e){
+			logger.error("Error", e);
 			sc.clearJobGroup();
 			return new InterpreterResult(Code.ERROR, e.getMessage());
 		}

--- a/spark/src/test/java/com/nflabs/zeppelin/spark/SparkSqlInterpreterTest.java
+++ b/spark/src/test/java/com/nflabs/zeppelin/spark/SparkSqlInterpreterTest.java
@@ -45,7 +45,7 @@ public class SparkSqlInterpreterTest {
 		assertEquals("name\tage\nmoon\t33\npark\t34\n", ret.message());
 		
 		assertEquals(InterpreterResult.Code.ERROR, sql.interpret("select wrong syntax").code());
-
+		assertEquals(InterpreterResult.Code.ERROR, sql.interpret("select case when name==\"aa\" then name else name end from people").code());
 	}
 
 }


### PR DESCRIPTION
Some errors from spark sql is not cached and displayed.
This PR fixes the problem.

for example

```
select case when a==1 then a else 0 end from tbl
```

is not supported in spark 1.1 and throw some exception but zeppelin couldn't catch and display error before this PR.

Ready to be merged.
