### PR TITLE
ZEPPELIN-162 shadow for paragraph instead of border

### DIFF
--- a/zeppelin-web/app/styles/notebook.css
+++ b/zeppelin-web/app/styles/notebook.css
@@ -18,7 +18,7 @@
   padding: 0 0 0 0px;
 }
 .paragraph {
-  padding: 0px 8px 8px 8px;
+  padding: 2px 8px 4px 8px;
   min-height: 32px;
 }
 
@@ -90,11 +90,10 @@
 }
 
 .outlineOnFocus{
-  border : 1px solid #FFFFFF;
 }
 
 .outlineOnFocus:hover{
-  border : 1px solid #EEEEEE;
+  box-shadow: 2px 2px 10px #888888;
 }
 
 .paragraph .control {


### PR DESCRIPTION
[ZEPPELIN-162](https://zeppelin-project.atlassian.net/browse/ZEPPELIN-162)
@anthonycorbacho mentioned sometimes it's hard to recognize paragraph's dimension at #106 
One of the reason i think is, on mouse over paragraph, border appears, but the color and width of border is too light.

I changed it to shadow, like screenshots below

![image](https://cloud.githubusercontent.com/assets/1540981/4372198/bdb1db4c-4321-11e4-8216-be892ef02f44.png)

Looks better? ready to go.
