### PR TITLE
Selectively deploy submodule into maven repository

### DIFF
--- a/markdown/pom.xml
+++ b/markdown/pom.xml
@@ -49,6 +49,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>            
         <executions> 

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -49,6 +49,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>            
         <executions> 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -236,6 +236,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>            
         <executions> 

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -56,6 +56,16 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
     </plugins>
 
   </build>

--- a/zeppelin-docs/pom.xml
+++ b/zeppelin-docs/pom.xml
@@ -73,6 +73,15 @@
 	  </execution>
 	</executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -309,7 +309,14 @@
 	  <argLine>-Xmx2048m</argLine>
         </configuration>
       </plugin>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <version>1.6</version>

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -39,7 +39,14 @@
           </filesets>
         </configuration>
       </plugin>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>


### PR DESCRIPTION
Until now, Zeppelin deployed all it's submodule into maven repository.
Tough not all submodule need to be in maven.

This PR disables some submodule that does not need to be in maven repository.

Disabled submodule
- zeppelin-server
- zeppelin-docs
- zeppelin-web
- zeppelin-distribution
- spark
- markdown
- shell

Enabled submodule
- zeppelin-zengine (to develop custom interpreter)
