### PR TITLE
PEL-395: Fixing zeppelin-web build error on CentOS 6.5

### DIFF
--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -13,7 +13,7 @@
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-cssmin": "^0.9.0",
     "grunt-contrib-htmlmin": "^0.3.0",
-    "grunt-contrib-imagemin": "^0.7.0",
+    "grunt-contrib-imagemin": "^0.8.1",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
grunt-contrib-imagemin fails to install on CentOS 6.5
