### PR TITLE
Text format use ng-bind instead of ng-bind-html

### DIFF
--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
@@ -98,7 +98,6 @@ public class SparkSqlInterpreter extends Interpreter {
 			
 		// ArrayType, BinaryType, BooleanType, ByteType, DecimalType, DoubleType, DynamicType, FloatType, FractionalType, IntegerType, IntegralType, LongType, MapType, NativeType, NullType, NumericType, ShortType, StringType, StructType
 		
-		int numRows=0;
 		for(int r = 0; r<maxResult && r<rows.length; r++){			
 			Row row = rows[r];
 			

--- a/spark/src/test/java/com/nflabs/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/src/test/java/com/nflabs/zeppelin/spark/SparkInterpreterTest.java
@@ -65,4 +65,12 @@ public class SparkInterpreterTest {
 		repl2.getSparkContext().stop();
 	}
 
+	@Test
+	public void testReferencingUndefinedVal(){
+		InterpreterResult result = repl.interpret("def category(min: Int) = {" +
+				       "    if (0 <= value) \"error\"" +
+                       "}");
+		assertEquals(Code.ERROR, result.code());
+		System.out.println("msg="+result.message());
+	}
 }

--- a/zeppelin-web/app/views/paragraph.html
+++ b/zeppelin-web/app/views/paragraph.html
@@ -269,7 +269,7 @@ limitations under the License.
            class="text"
            ng-if="paragraph.result.type == 'TEXT' || (paragraph.result.type == 'TABLE' && paragraph.result.msg)"
            ng-Init="loadResultType(paragraph.result)"
-           ng-bind-html="paragraph.result.msg">
+           ng-bind="paragraph.result.msg">
       </div>
 
       <div id="{{paragraph.id}}_msg"


### PR DESCRIPTION
Fix for #131.
There were bug, contents were always rendered as html even if content is not starting with '%html'.
Also implementing unittest to confirm Zeppelin raise error in #131 case.

Ready to merge.
