### PR TITLE
ZEPPELIN-174 don't apply emacs key binding when running on windows

### DIFF
--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -381,7 +381,13 @@ angular.module('zeppelinWebApp')
 
       $scope.editor.getSession().setUseWrapMode(true);
 
-      $scope.editor.setKeyboardHandler("ace/keyboard/emacs");
+      if (navigator.appVersion.indexOf("Mac")!=-1 ||
+          navigator.appVersion.indexOf("X11")!=-1 ||
+          navigator.appVersion.indexOf("Linux")!=-1) {
+        $scope.editor.setKeyboardHandler("ace/keyboard/emacs");
+      } else if (navigator.appVersion.indexOf("Win")!=-1) {
+        // not applying emacs key binding while the binding override Ctrl-v. default behavior of paste text on windows.
+      }
 
       $scope.editor.setOptions({
           enableBasicAutocompletion: true,


### PR DESCRIPTION
[ZEPPELIN-174](https://zeppelin-project.atlassian.net/browse/ZEPPELIN-174)

Emacs key binding override ctrl-v which default behavior text paste on windows.
this PR detect operating system that browser running on and not apply emacs key binding when it's running on windows.

Ready to merge.
