### PR TITLE
Not destroying interpreters in shared mode

### DIFF
--- a/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/notebook/NoteInterpreterLoader.java
+++ b/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/notebook/NoteInterpreterLoader.java
@@ -57,6 +57,7 @@ public class NoteInterpreterLoader {
 			Interpreter repl = loadedInterpreters.get(k);
 			repl.close();
 			repl.destroy();
+			loadedInterpreters.remove(k);
 		}
 	}
 	


### PR DESCRIPTION
When zeppelin.interpreter.mode is 'share', interpreter should not be destroyed when notebook is removed. because of interpreters are used in other notebooks.
