### PR TITLE
Copy & Paste does not work on linux

### DIFF
--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -385,11 +385,11 @@ angular.module('zeppelinWebApp')
       setEditorHeight(_editor.container.id, hight);
 
       $scope.editor.getSession().setUseWrapMode(true);
-      if (navigator.appVersion.indexOf("Mac")!=-1 ||
-          navigator.appVersion.indexOf("X11")!=-1 ||
-          navigator.appVersion.indexOf("Linux")!=-1) {
+      if (navigator.appVersion.indexOf("Mac")!=-1 ) {
         $scope.editor.setKeyboardHandler("ace/keyboard/emacs");
-      } else if (navigator.appVersion.indexOf("Win")!=-1) {
+      } else if (navigator.appVersion.indexOf("Win")!=-1 ||
+                 navigator.appVersion.indexOf("X11")!=-1 ||
+                 navigator.appVersion.indexOf("Linux")!=-1) {
         // not applying emacs key binding while the binding override Ctrl-v. default behavior of paste text on windows.
       }
 


### PR DESCRIPTION
Copy & Paste does not work on linux. (https://groups.google.com/forum/#!topic/zeppelin-developers/0UTkLuoi8Dc)

Disabling emacs key binding on linux
