### PR TITLE
disable page cache

### DIFF
--- a/zeppelin-web/app/index.html
+++ b/zeppelin-web/app/index.html
@@ -18,6 +18,13 @@ limitations under the License.
   <head>
     <meta charset="utf-8">
     <title></title>
+    <!-- disable caches for all browser -->
+    <meta http-equiv="cache-control" content="max-age=0" />
+    <meta http-equiv="cache-control" content="no-cache" />
+    <meta http-equiv="expires" content="0" />
+    <meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
+    <meta http-equiv="pragma" content="no-cache" />
+
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->


### PR DESCRIPTION
Since Zeppelin is fast developing project including interactive web UIs, 
page cache has always been a trouble after updating Zeppelin. 
This PR disables page cache for all browser. 
