### PR TITLE
Workaround for failed build caused by https://nodejs.org redirect

### DIFF
--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -64,7 +64,6 @@
               <npmVersion>1.3.8</npmVersion>
             </configuration>
           </execution>
-          -->
 
           <execution>
             <id>npm install ansi-color</id>
@@ -76,6 +75,7 @@
               <arguments>install http://registry.npmjs.org/ansi-color/-/ansi-color-0.2.1.tgz</arguments>
             </configuration>
           </execution>
+          -->
 
           <execution>
             <id>npm install</id>


### PR DESCRIPTION
Builds of #160 and #159 failed due to https://github.com/eirslett/frontend-maven-plugin/issues/99 which originated from nodejs.org chainging their policy and now serving contentn through https:// only.

This is workaround to get build green on Travis again, clean build will require to have node.js installed on a machine

rontend-maven-plugin version should be bumped later after to have a proper fix.
