### PR TITLE
 Run code as a paragraph

### DIFF
--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import com.nflabs.zeppelin.interpreter.Interpreter;
 import com.nflabs.zeppelin.interpreter.InterpreterResult;
 import com.nflabs.zeppelin.interpreter.InterpreterResult.Code;
+import com.nflabs.zeppelin.notebook.NoteInterpreterLoader;
 import com.nflabs.zeppelin.notebook.Paragraph;
 import com.nflabs.zeppelin.notebook.form.Setting;
 import com.nflabs.zeppelin.scheduler.Scheduler;
@@ -267,7 +268,9 @@ Alternatively you can set the class path throuh nsc.Settings.classpath.
 		sqlc = getSQLContext();
 		
 		dep = getDependencyResolver();
-		z = new ZeppelinContext(sc, sqlc, dep);
+		
+		NoteInterpreterLoader noteInterpreterLoader = (NoteInterpreterLoader) getProperty().get("noteIntpLoader");
+		z = new ZeppelinContext(sc, sqlc, dep, noteInterpreterLoader, printStream);
 
         this.interpreter.loadFiles(settings);
 

--- a/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/notebook/NoteInterpreterLoader.java
+++ b/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/notebook/NoteInterpreterLoader.java
@@ -39,10 +39,11 @@ public class NoteInterpreterLoader {
 			return loadedInterpreters.get(name);
 		} else {
 			Properties p = new Properties();
+			p.put("noteIntpLoader", this);
 			Interpreter repl = factory.createRepl(name, p);
-			
-			loadedInterpreters.put(name, new LazyOpenInterpreter(repl));			
-			return repl;
+			LazyOpenInterpreter lazyIntp = new LazyOpenInterpreter(repl);
+			loadedInterpreters.put(name, lazyIntp);			
+			return lazyIntp;
 		}
 	}
 	

--- a/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/notebook/Paragraph.java
@@ -64,7 +64,7 @@ public class Paragraph extends Job implements Serializable {
     return getRequiredReplName(text);
   }
   
-  private String getRequiredReplName(String text) {
+  public static String getRequiredReplName(String text) {
     if (text == null)
       return null;
 
@@ -91,7 +91,7 @@ public class Paragraph extends Job implements Serializable {
     return getScriptBody(text); 
   }
 
-  private String getScriptBody(String text) {
+  public static String getScriptBody(String text) {
     if (text == null)
       return null;
 


### PR DESCRIPTION
This PR gives ability to run code as a paragraph, programmatically.
By implementing

```
ZeppelinContext.run(String code);
```

For example, if there're one paragraph like,

```
%md ### Hello Zeppelin
```

then, equivalent code is 

```
z.run("%md ### Hello Zeppelin")
```

This feature is useful because it can construct paragraph programmatically. For example

![image](https://cloud.githubusercontent.com/assets/1540981/4775150/f46711ba-5bb4-11e4-8ece-5af8980b236d.png)
