### PR TITLE
Newly created note can not load looknfeel after first run, until user manually change looknfeel

### DIFF
--- a/zeppelin-web/app/scripts/controllers/main.js
+++ b/zeppelin-web/app/scripts/controllers/main.js
@@ -110,7 +110,7 @@ angular.module('zeppelinWebApp')
   });
 
   $rootScope.$on('setLookAndFeel', function(event, data) {
-    if (!event.defaultPrevented && data && data !== "") {
+    if (!event.defaultPrevented && data && data !== '') {
       $scope.looknfeel = data;
       event.preventDefault();
     }


### PR DESCRIPTION
Newly create note sets looknfeel 'default' by default.
But when run a paragraph, the looknfeel (internall) change to empty one and failed to load related css.
Until user manually change looknfeel again.

This PR solves the problem.
Ready to merge.
