### PR TITLE
no chart animation when data is large

### DIFF
--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -807,11 +807,20 @@ angular.module('zeppelinWebApp')
 
       var height = $scope.paragraph.config.graph.height;
 
+      var animationDuration = 300;
+      var numberOfDataThreshold = 150;
+      // turn off animation when dataset is too large. (for performance issue)
+      // still, since dataset is large, the chart content sequentially appears like animated.
+      try {
+        if (d3g[0].values.length > numberOfDataThreshold) animationDuration = 0;
+      } catch(ignoreErr) {
+      }
+
       var chartEl = d3.select('#p'+$scope.paragraph.id+'_'+type+' svg')
           .attr('height', $scope.paragraph.config.graph.height)
           .datum(d3g) 
           .transition()
-          .duration(300)
+          .duration(animationDuration)
           .call($scope.chart[type]);
       d3.select('#p'+$scope.paragraph.id+'_'+type+' svg').style.height = height+'px';
       nv.utils.windowResize($scope.chart[type].update);


### PR DESCRIPTION
This PR disables chat animation when chat dataset is large. 

but still it appears with animation when data is large enough. (plz try the test codes below)

sc.parallelize((1 to 10).toList).map(x => (x, 1)).registerTempTable("test1")
sc.parallelize((1 to 100).toList).map(x => (x, 1)).registerTempTable("test2")
sc.parallelize((1 to 200).toList).map(x => (x, 1)).registerTempTable("test3")

// animated
%sql 
select \* from test1

// animated
%sql 
select \* from test2

// disabled animation but still appears like animated 
%sql 
select \* from test3
