### PR TITLE
Support for showing execution time of paragraph

### DIFF
--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -359,6 +359,7 @@ angular.module('zeppelinWebApp')
     commitParagraph($scope.paragraph.title, $scope.paragraph.text, newConfig, newParams);
   };
 
+
   $scope.loadForm = function(formulaire, params) {
     var value = formulaire.defaultValue;
     if (params[formulaire.name]) {
@@ -520,6 +521,13 @@ angular.module('zeppelinWebApp')
   $scope.getProgress = function(){
     return ($scope.currentProgress) ? $scope.currentProgress : 0;
   };
+
+  $scope.getExecutionTime = function() {
+    var pdata = $scope.paragraph;
+    var timeMs = Date.parse(pdata.dateFinished) - Date.parse(pdata.dateStarted);
+    return 'Took ' + (timeMs/1000) +  ' seconds';
+
+  }
 
   $rootScope.$on('updateProgress', function(event, data) {
     if (data.id === $scope.paragraph.id) {

--- a/zeppelin-web/app/styles/notebook.css
+++ b/zeppelin-web/app/styles/notebook.css
@@ -248,6 +248,12 @@
   z-index:100;
 }
 
+.paragraph .executionTime {
+  color: #999;
+  font-size: 10px;
+  font-family: 'Roboto', sans-serif;
+}
+
 
 .disable {
   opacity:0.4!important;

--- a/zeppelin-web/app/views/paragraph.html
+++ b/zeppelin-web/app/views/paragraph.html
@@ -64,6 +64,7 @@ limitations under the License.
       </div>
     </div>
 
+
     <form id="{{paragraph.id}}_form" role="form"
           class="form-horizontal">
       <div class="form-group"
@@ -272,6 +273,9 @@ limitations under the License.
            class="error"
            ng-if="paragraph.status == 'ERROR'"
            ng-bind="paragraph.errorMessage">
+      </div>
+      <div id="{{paragraph.id}}_executionTime" class="executionTime" ng-if="paragraph.status == 'FINISHED'">
+        {{getExecutionTime()}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR adds support for reporting execution time of a paragraph after completion.

![execution_time](https://cloud.githubusercontent.com/assets/5747419/4849890/008c3632-6065-11e4-8e23-027723f82ec1.png)
