### PR TITLE
Bringing code show/hide button back outside of dropdown for quickaccess

### DIFF
--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -268,6 +268,14 @@ angular.module('zeppelinWebApp')
     commitParagraph($scope.paragraph.title, $scope.paragraph.text, newConfig, newParams);
   };
 
+  $scope.toggleEditor = function() {
+    if ($scope.paragraph.config.editorHide) {
+      $scope.openEditor();
+    } else {
+      $scope.closeEditor();
+    }
+  };
+
   $scope.closeEditor = function() {
     console.log('close the note');
 

--- a/zeppelin-web/app/views/paragraph.html
+++ b/zeppelin-web/app/views/paragraph.html
@@ -296,7 +296,10 @@ limitations under the License.
     <span class="icon-control-pause" style="cursor:pointer;color:#CD5C5C" tooltip-placement="top" tooltip="Cancel"
           ng-click="cancelParagraph()"
           ng-show="paragraph.status=='RUNNING' || paragraph.status=='PENDING'"></span>
-  <span class="{{paragraph.config.tableHide ? 'icon-notebook' : 'icon-book-open'}}" tooltip-placement="top" tooltip="{{(paragraph.config.tableHide ? 'Show' : 'Hide') + ' output'}}"
+
+    <span class="{{paragraph.config.editorHide ? 'icon-size-fullscreen' : 'icon-size-actual'}}" tooltip-placement="top" tooltip="{{(paragraph.config.editorHide ? 'Show' : 'Hide') + ' editor'}}"
+	  ng-click="toggleEditor()"></span>
+    <span class="{{paragraph.config.tableHide ? 'icon-notebook' : 'icon-book-open'}}" tooltip-placement="top" tooltip="{{(paragraph.config.tableHide ? 'Show' : 'Hide') + ' output'}}"
 	  ng-click="toggleOutput()"></span>
 
     <span class="dropdown navbar-right">
@@ -335,18 +338,6 @@ limitations under the License.
           <a class="fa fa-font" style="cursor:pointer"
                 ng-click="showTitle()"
                 ng-show="!paragraph.config.title"> Show title</a>
-        </li>
-
-        <li>
-          <!-- Editor handler -->
-          <a style="cursor:pointer"
-                class="fa fa-code"
-                ng-click="closeEditor()"
-                ng-show="!paragraph.config.editorHide && !paragraph.config.hide"> Hide code editor</a>
-          <a style="cursor:pointer"
-                class="fa fa-code"
-                ng-click="openEditor()"
-                ng-show="paragraph.config.editorHide && !paragraph.config.hide"> Show code editor</a>
         </li>
 
         <li>


### PR DESCRIPTION
Currently, output show/hide button of paragraph is placed outside of setting dropdown menu.
Why don't we place code show/hide button together?

![image](https://cloud.githubusercontent.com/assets/1540981/4968168/10e09bc6-6836-11e4-9fca-b22c2c961ff3.png)

Ready to merge.
