### PR TITLE
Fix/Improve daemon script

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -112,7 +112,12 @@ if [ "x$ZEPPELIN_ENCODING" == "x" ]; then
   export ZEPPELIN_ENCODING="UTF-8"
 fi
 
-JAVA_OPTS+="$ZEPPELIN_JAVA_OPTS -Dfile.encoding=${ZEPPELIN_ENCODING} -Xmx1024m -XX:MaxPermSize=512m"
+if [ "x$ZEPPELIN_MEM" == "x" ]; then
+  export ZEPPELIN_MEM="-Xmx1024m -XX:MaxPermSize=512m"
+fi
+
+
+JAVA_OPTS+="$ZEPPELIN_JAVA_OPTS -Dfile.encoding=${ZEPPELIN_ENCODING} ${ZEPPELIN_MEM}"
 export JAVA_OPTS
 
 if [ -n "$JAVA_HOME" ]; then

--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -1,10 +1,9 @@
 #!/bin/bash
 
 # export JAVA_HOME=
-# export HADOOP_HOME=            # Required except for setting with Hive Server
-
 # export MASTER=                 # spark master
-# export SPARK_HOME=             # spark home
+# export ZEPPELIN_JAVA_OPTS      # additional jvm options. for example, export ZEPPELIN_JAVA_OPTS="-Dspark.executor.memory=8g -Dspark.cores.max=16"
+# export ZEPPELIN_MEM            # zeppelin jvm mem options Defualt -Xmx1024m -XX:MaxPermSize=512m
 
 # export ZEPPELIN_CONF_DIR       # Alternate zeppelin conf dir. Default is ${HBASE_HOME}/conf.
 # export ZEPPELIN_LOG_DIR        # Where log files are stored.  PWD by default.
@@ -12,4 +11,3 @@
 # export ZEPPELIN_NOTEBOOK_DIR   # Where notebook saved
 # export ZEPPELIN_IDENT_STRING   # A string representing this instance of zeppelin. $USER by default
 # export ZEPPELIN_NICENESS       # The scheduling priority for daemons. Defaults to 0.
-# export ZEPPELIN_JAVA_OPTS      # Additional jvm option


### PR DESCRIPTION
After creating distribution package using following command,

```
mvn package -Pbuild-distr 
```

Zeppelin can not find zeppelin-web*.war and fails to load web ui.
This PR fix the problem and improve zeppelin-env.sh little bit.
- [x] Fix problem finding zeppelin-web*.war
- [x] Let user define JVM mem option in zeppelin-env.sh

Ready to merge.
