### PR TITLE
Fix background color for selected words, selected autocompletion list

### DIFF
--- a/zeppelin-web/app/styles/notebook.css
+++ b/zeppelin-web/app/styles/notebook.css
@@ -69,6 +69,11 @@
 
 .ace-tm .ace_marker-layer .ace_selection {
     background: rgba(98, 157, 233, 0.2) !important;
+    color: black;
+}
+
+.ace_active-line {
+    background: rgba(98, 157, 233, 0.2) !important;
 }
 
 .ace-tm .ace_marker-layer .ace_selected-word {


### PR DESCRIPTION
This PR fixes background color

from
![image](https://cloud.githubusercontent.com/assets/1540981/5187192/ab88b638-750e-11e4-8caf-6f4c623180d2.png)

to
![image](https://cloud.githubusercontent.com/assets/1540981/5187063/c4356fa6-750d-11e4-8eaf-81025ec70793.png)

from
![image](https://cloud.githubusercontent.com/assets/1540981/5187077/ee860c20-750d-11e4-92bf-83cca1f7d9b2.png)

to
![image](https://cloud.githubusercontent.com/assets/1540981/5187067/da57d922-750d-11e4-9113-a2308a0a1835.png)

Ready to merge
