### PR TITLE
Use proxy for resizable

### DIFF
--- a/zeppelin-web/app/scripts/directives/resizable.js
+++ b/zeppelin-web/app/scripts/directives/resizable.js
@@ -4,6 +4,7 @@ angular.module('zeppelinWebApp').directive('resizable', function () {
     var resizableConfig = {
         autoHide: true,
         handles: 'se',
+        helper: 'resizable-helper',
         minHeight:100,
         grid: [10000, 10]  // allow only vertical
     };

--- a/zeppelin-web/app/styles/notebook.css
+++ b/zeppelin-web/app/styles/notebook.css
@@ -455,3 +455,7 @@
 .lightBold {
   font-weight: 500;
 }
+
+.resizable-helper {
+  border: 3px solid #DDDDDD;
+}


### PR DESCRIPTION
When the output is %table, paragraph height is changeable.
This PR make resizable handle use proxy instead of realtime change of element size, for performance reason.

Ready to merge.
