### PR TITLE
Improve pivot chart behavior

### DIFF
--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -811,7 +811,7 @@ angular.module('zeppelinWebApp')
         }
       }
     } else if (type==='multiBarChart') {
-      d3g = pivotDataToD3ChartFormat(p, true).d3g;
+      d3g = pivotDataToD3ChartFormat(p, true, false, type).d3g;
       $scope.chart[type].yAxis.axisLabelDistance(50);
     } else {
       var pivotdata = pivotDataToD3ChartFormat(p, false, true);
@@ -1127,7 +1127,7 @@ angular.module('zeppelinWebApp')
     };
   };
 
-  var pivotDataToD3ChartFormat = function(data, allowTextXAxis, fillMissingValues) {
+  var pivotDataToD3ChartFormat = function(data, allowTextXAxis, fillMissingValues, chartType) {
     // construct d3 data
     var d3g = [];
 
@@ -1157,7 +1157,7 @@ angular.module('zeppelinWebApp')
         rowName = concat(rowName, sKey);
         rowValue = concat(rowValue, rKey);
       } else if (s.type==='group') {
-        colName = concat(colName, sKey);
+        colName = concat(colName, rKey);
       } else if (s.type==='value' && sKey===rKey || valueOnly) {
         colName = concat(colName, rKey);
         func(rowName, rowValue, colName, r);
@@ -1182,7 +1182,9 @@ angular.module('zeppelinWebApp')
     var keys = $scope.paragraph.config.graph.keys;
     var groups = $scope.paragraph.config.graph.groups;
     var values = $scope.paragraph.config.graph.values;
-    var valueOnly = (keys.length===0 && groups.length===0 && values.length>0);
+    var valueOnly = (keys.length === 0 && groups.length === 0 && values.length > 0);
+    var noKey = (keys.length === 0);
+    var isMultiBarChart = (chartType === 'multiBarChart');
 
     var sKey = Object.keys(schema)[0];
 
@@ -1204,14 +1206,14 @@ angular.module('zeppelinWebApp')
           colNameIndex[colName] = colIdx++;
         }
         var i = colNameIndex[colName];
-        if (valueOnly) {
+        if (noKey && isMultiBarChart) {
           i = 0;
         }
 
         if (!d3g[i]) {
           d3g[i] = {
             values : [],
-            key : (valueOnly) ? 'values' : colName
+            key : (noKey && isMultiBarChart) ? 'values' : colName
           };
         }
 


### PR DESCRIPTION
**Before**
When there is no keys in pivot setting, chart showed only one group even when there is more than one group.
![2015-01-02 11 50 13](https://cloud.githubusercontent.com/assets/8503346/5594036/c3fc8dc0-9278-11e4-88d4-32d80cb8b0c5.png)

**After**
When there is no keys but groups and values, show the multi-bar chart as one group named 'values'.
![2015-01-02 12 17 00](https://cloud.githubusercontent.com/assets/8503346/5594049/552a0f98-9279-11e4-9430-659efb8525fc.png)

**Before**
![2015-01-02 11 30 11](https://cloud.githubusercontent.com/assets/8503346/5594038/c6b7d628-9278-11e4-8448-cd0abfc2eed6.png)

**After**
Use origin value name as legend instead of 'values'.
![2015-01-02 11 47 56](https://cloud.githubusercontent.com/assets/8503346/5594039/c7e0bbbe-9278-11e4-9327-00499b9a0c45.png)
