### PR TITLE
Link snapshot binary instead of broken 0.4.0 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Zeppelin 
 
-**Now, out in [Version 0.4.0](https://github.com/NFLabs/zeppelin/releases/tag/release-0.4.0)!**<br/>
+**Latest binary build** [Version-0.5.0-SNAPSHOT](https://github.com/NFLabs/zeppelin/releases/tag/snapshot-0.5.0)<br />
 **Documentation:** [User Guide](http://zeppelin-project.org/docs/index.html)<br/>
 **Mailing List:** [Mailing List](https://groups.google.com/forum/#!forum/zeppelin-developers) <br/>
 **Continuous Integration:** [![Build Status](https://secure.travis-ci.org/NFLabs/zeppelin.png?branch=master)](https://travis-ci.org/NFLabs/zeppelin) <br/>


### PR DESCRIPTION
https://github.com/NFLabs/zeppelin has link to old binary build which is not really working.

As more people reporting a problem that this binary package does not work, I have created new pre-release at github and binary build attached. https://github.com/NFLabs/zeppelin/releases/tag/snapshot-0.5.0. Readme.md file updated to point this link instead of old 0.4.0 release.

Ready to merge.

