### PR TITLE
Force ace-angular version to 0.1.1

### DIFF
--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -14,7 +14,7 @@
     "angular-bootstrap": "~0.11.0",
     "angular-websocket": "~0.0.5",
     "ace-builds": "1.1.6",
-    "angular-ui-ace": "~0.1.1",
+    "angular-ui-ace": "0.1.1",
     "jquery.scrollTo": "~1.4.13",
     "nvd3": "~1.1.15-beta",
     "angular-dragdrop": "~1.0.8",


### PR DESCRIPTION
With the newer version of this plugin (0.1.3), ace editor is not working

Also, dont forget to clean your bower cache:

```
bower cache clean
bower install
```
