### PR TITLE
Remove 0.4.0 binary link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ To know more about Zeppelin, visit our web site [http://zeppelin-project.org](ht
 
 ## Getting Started
 
-### Installation
-Download Zeppelin from [https://github.com/NFLabs/zeppelin/releases](https://github.com/NFLabs/zeppelin/releases) and extract the content.
-
 ### Build
 If you want to build Zeppelin from the souce, please first clone this repository. And then:
 ```


### PR DESCRIPTION
Tried to remove binary link to broken 0.4.0 package by #269.
This PR removes another link that missed at #269.

As many people get confused by this broken binary release, i'll merge it right now to remove that link immediately.