### PR TITLE
Spark 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
 		<spark.version>1.1.1</spark.version>
 		<scala.version>2.10.4</scala.version>
 		<scala.binary.version>2.10</scala.binary.version>
+                <scala.macros.version>2.0.1</scala.macros.version>
 		<mesos.version>0.18.1</mesos.version>
 		<mesos.classifier>shaded-protobuf</mesos.classifier>
 		<akka.group>org.spark-project.akka</akka.group>
@@ -93,6 +94,7 @@
 		<hbase.version>0.94.6</hbase.version>
 		<zookeeper.version>3.4.5</zookeeper.version>
 		<hive.version>0.12.0</hive.version>
+                <derby.version>10.4.2.0</derby.version>
 		<parquet.version>1.4.3</parquet.version>
 		<jblas.version>1.2.3</jblas.version>
 		<jetty.version>8.1.14.v20131031</jetty.version>
@@ -100,9 +102,12 @@
 		<codahale.metrics.version>3.0.0</codahale.metrics.version>
 		<avro.version>1.7.6</avro.version>
 		<jets3t.version>0.7.1</jets3t.version>
+                <commons.math3.version>3.2</commons.math3.version>
+                <commons.httpclient.version>4.3.6</commons.httpclient.version>
+                <io.netty.version>4.0.17.Final</io.netty.version>
+
 		<guava.version>15.0</guava.version>
 		<scalatest.version>2.2.1</scalatest.version>
-
 		<PermGen>64m</PermGen>
 		<MaxPermGen>512m</MaxPermGen>
 
@@ -163,7 +168,7 @@
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
-				<version>4.3.6</version>
+				<version>${commons.httpclient.version}</version>
 			</dependency>
 
 			<dependency>
@@ -193,7 +198,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-math3</artifactId>
-				<version>3.2</version>
+				<version>${commons.math3.version}</version>
 			</dependency>
 
 			<dependency>
@@ -393,7 +398,7 @@
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-all</artifactId>
-				<version>4.0.17.Final</version>
+				<version>${io.netty.version}</version>
 			</dependency>
 
 			<dependency>
@@ -405,7 +410,7 @@
 			<dependency>
 				<groupId>org.apache.derby</groupId>
 				<artifactId>derby</artifactId>
-				<version>10.4.2.0</version>
+				<version>${derby.version}</version>
 			</dependency>
 
 			<dependency>
@@ -1191,6 +1196,33 @@
 				</plugins>
 			</build>
 		</profile>
+
+                <profile>
+                        <id>spark-1.1</id>
+                        <dependencies>
+                               
+                        </dependencies>
+                        <properties>
+                                <spark.version>1.1.1</spark.version>
+                        </properties>
+                </profile>
+
+                <profile>
+                        <id>spark-1.2</id>
+                        <dependencies>
+                        </dependencies>
+                        <properties>
+                                <akka.version>2.3.4-spark</akka.version>
+                                <spark.version>1.2.0</spark.version>
+		                <hive.version>0.13.1a</hive.version>
+                                <derby.version>10.10.1.1</derby.version>
+		                <parquet.version>1.6.0rc3</parquet.version>
+		                <chill.version>0.5.0</chill.version>
+                                <commons.httpclient.version>4.2.6</commons.httpclient.version>
+                                <commons.math3.version>3.1.1</commons.math3.version>
+                                <io.netty.version>4.0.23.Final</io.netty.version>
+                        </properties>
+                </profile>
 
 		<profile>
 			<id>hadoop-0.23</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1213,7 +1213,7 @@
                         </dependencies>
                         <properties>
                                 <akka.version>2.3.4-spark</akka.version>
-                                <spark.version>1.2.0</spark.version>
+                                <spark.version>1.2.1</spark.version>
 		                <hive.version>0.13.1a</hive.version>
                                 <derby.version>10.10.1.1</derby.version>
 		                <parquet.version>1.6.0rc3</parquet.version>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -85,7 +85,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.17.Final</version>
     </dependency>
 
     <dependency>
@@ -117,6 +116,12 @@
    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-streaming-twitter_2.10</artifactId>
+      <version>${spark.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
             

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -423,6 +423,8 @@ public class SparkInterpreter extends Interpreter {
           progressInfo = getProgressFromStage_1_0x(sparkListener, job.finalStage());
         } else if (sc.version().startsWith("1.1")) {
           progressInfo = getProgressFromStage_1_1x(sparkListener, job.finalStage());
+        } else if (sc.version().startsWith("1.2")) {
+          progressInfo = getProgressFromStage_1_1x(sparkListener, job.finalStage());
         } else {
           continue;
         }

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
@@ -193,6 +193,8 @@ public class SparkSqlInterpreter extends Interpreter {
           progressInfo = getProgressFromStage_1_0x(sparkListener, job.finalStage());
         } else if (sc.version().startsWith("1.1")) {
           progressInfo = getProgressFromStage_1_1x(sparkListener, job.finalStage());
+        } else if (sc.version().startsWith("1.2")) {
+          progressInfo = getProgressFromStage_1_1x(sparkListener, job.finalStage());
         } else {
           logger.warn("Spark {} getting progress information not supported" + sc.version());
           continue;


### PR DESCRIPTION
Trying to Zeppelin work with Spark 1.2

#### How to test this branch

1. Build and install spark artifact locally (for spark-repl.jar)

Because of spark-repl artifact is not yet released for 1.2 version, need to build and deploy locally, before build Zeppelin.
To do that, clone spark 1.2 source and run

```
sbt/sbt publish-local
```

2. Checkout this spark_1.2 branch and build Zeppelin with spark-1.2 profile

```
mvn -DskipTests -Pspark-1.2 package
```

Here's simple test i did in local mode.

![image](https://cloud.githubusercontent.com/assets/1540981/5830487/a924de94-a164-11e4-84ef-d41c3492867b.png)

