### PR TITLE
Fix Zeppelin web build

### DIFF
--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -237,25 +237,6 @@ module.exports = function (grunt) {
     //   dist: {}
     // },
 
-    imagemin: {
-      dist: {
-        files: [{
-          expand: true,
-          cwd: '<%= yeoman.app %>/images',
-          src: '{,*/}*.{png,jpg,jpeg,gif}',
-          dest: '<%= yeoman.dist %>/images'
-        }]
-      },
-      jqueryui: {
-        files: [{
-          expand: true,
-          cwd: 'bower_components/jquery-ui/themes/base/images',
-          src: '{,*/}*.{png,jpg,jpeg,gif}',
-          dest: '<%= yeoman.dist %>/styles/images'
-        }]
-      }
-    },
-
     svgmin: {
       dist: {
         files: [{
@@ -312,7 +293,7 @@ module.exports = function (grunt) {
             '.htaccess',
             '*.html',
             'views/{,*/}*.html',
-            'images/{,*/}*.{webp}',
+            'images/*',
             'fonts/*',
             'WEB-INF/*',
             'scripts/ace/{,*/}/{,*/}/*'
@@ -333,6 +314,11 @@ module.exports = function (grunt) {
           cwd: 'bower_components/bootstrap/dist',
           src: 'fonts/*',
           dest: '<%= yeoman.dist %>'
+        }, {
+          expand: true,
+          cwd: 'bower_components/jquery-ui/themes/base/images',
+          src: '{,*/}*.{png,jpg,jpeg,gif}',
+          dest: '<%= yeoman.dist %>/styles/images'
         }]
       },
       styles: {
@@ -353,8 +339,6 @@ module.exports = function (grunt) {
       ],
       dist: [
         'copy:styles',
-        'imagemin',
-        'imagemin:jqueryui',
         'svgmin'
       ]
     },

--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -416,7 +416,11 @@ module.exports = function (grunt) {
 
   grunt.registerTask('default', [
     'newer:jshint',
+    /*
+     * Since we dont have test (or up to date) there is no reason to keep this task
+     * I am commented this, but can be changed in the future (if someone want to implement front tests).
     'test',
+    */
     'build'
   ]);
 };

--- a/zeppelin-web/README.md
+++ b/zeppelin-web/README.md
@@ -1,19 +1,33 @@
-# Zeppelin web application 2
+# Zeppelin Web Application
 This is a Zeppelin web frontend project.
 
-## Get started 
-The first thing you need to do is install Yeoman. We’re going to use the Node Package Manager to do this all at once.
- * `npm install -g yo`
- * `npm install -g generator-angular`
 
-### Get the application deps
-* `npm install`
+## Compile Zeppelin web
+If you want to compile the WebApplication, you will have to simply run `mvn package`.
+This will Download all the dependencies including node js and npm (you will find the binaries in the folder `zeppelin-web/node`).
 
-## Run the application in dev mode
+We also provide some **helper script** for bower and grunt (you dont need to install them).
+
+In case of the error `ECMDERR Failed to execute "git ls-remote --tags --heads git://xxxxx", exit code of #128`
+Try to add to the `.bowerrc` file the following content:
+```
+  "proxy" : "http://<host>:<port>",
+  "https-proxy" : "http://<host>:<port>"
+```
+and retry to build again.
+
+## Contribute on Zeppelin Web
+If you wish to help us to contribute on Zeppelin Web, you will need to install some deps.
+Here this is a good start to understand how zeppelin web is architectured.
+http://www.sitepoint.com/kickstart-your-angularjs-development-with-yeoman-grunt-and-bower/
+
+### Run the application in dev mode
 ``./grunt serve``
 
+### Build the application
+`./grunt build`
 
-## Add composents the the web app
+### Add composents to Zeppelin Webapp
  * New controller : `yo angular:controller <controlerName>`
  * New directive : `yo angular:directive <directiveName>`
  * New service : `yo angular:service <serviceName>`
@@ -28,11 +42,6 @@ The first thing you need to do is install Yeoman. We’re going to use the Node 
  <script src="bower_components/angular-nvd3/dist/angular-nvd3.js"></script>
  ````
 
-## Build the application
-`./grunt build`
 
-## Deployment 
-`mvn package`, will create the war file.
 
-#### More info
-http://www.sitepoint.com/kickstart-your-angularjs-development-with-yeoman-grunt-and-bower/
+

--- a/zeppelin-web/README.md
+++ b/zeppelin-web/README.md
@@ -9,11 +9,18 @@ This will Download all the dependencies including node js and npm (you will find
 We also provide some **helper script** for bower and grunt (you dont need to install them).
 
 In case of the error `ECMDERR Failed to execute "git ls-remote --tags --heads git://xxxxx", exit code of #128`
+
+change your git config with `git config --global url."https://".insteadOf git://`
+
+**OR**
+
 Try to add to the `.bowerrc` file the following content:
 ```
   "proxy" : "http://<host>:<port>",
   "https-proxy" : "http://<host>:<port>"
 ```
+
+
 and retry to build again.
 
 ## Contribute on Zeppelin Web

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -13,7 +13,7 @@
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-cssmin": "^0.9.0",
     "grunt-contrib-htmlmin": "^0.3.0",
-    "grunt-contrib-imagemin": "^0.8.1",
+    "grunt-contrib-imagemin": "0.9.2",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-contrib-watch": "^0.6.1",
@@ -34,9 +34,5 @@
   },
   "engines": {
     "node": ">=0.10.0"
-  },
-  "scripts": {
-    "postinstall" : "./node_modules/bower/bin/bower --allow-root install",
-    "test": "grunt test"
   }
 }

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -13,7 +13,6 @@
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-cssmin": "^0.9.0",
     "grunt-contrib-htmlmin": "^0.3.0",
-    "grunt-contrib-imagemin": "0.9.2",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-contrib-watch": "^0.6.1",

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
+<!-- 
+  This is commented because somehow this force zeppelin-webb to be build 2 times.
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>com.nflabs.zeppelin</groupId>
     <version>0.5.0-SNAPSHOT</version>
   </parent>
-
+-->
   <groupId>com.nflabs.zeppelin</groupId>
   <artifactId>zeppelin-web</artifactId>
   <packaging>war</packaging>
@@ -15,38 +16,7 @@
   <name>Zeppelin: web Application</name>
 
   <build>
-    <finalName>zeppelin-web</finalName>
-
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>2.4.1</version>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>src/main/webapp</directory>
-              <includes>
-                <include>src/main/webapp/styles</include>
-                <include>src/main/webapp/scripts</include>
-                <include>src/main/webapp/font</include>
-                <include>src/main/webapp/images</include>
-                <include>src/main/webapp/views</include>
-                <include>src/main/webapp/*.html</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
@@ -54,7 +24,6 @@
         <executions>
           <execution>
             <id>install node and npm</id>
-            <phase>generate-sources</phase>
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
@@ -69,6 +38,7 @@
             <goals>
               <goal>npm</goal>
             </goals>
+            <phase>generate-resources</phase>
             <configuration>
               <arguments>install</arguments>
             </configuration>
@@ -79,8 +49,9 @@
             <goals>
               <goal>bower</goal>
             </goals>
+            <phase>generate-resources</phase>
             <configuration>
-              <arguments>install</arguments>
+              <arguments>--allow-root install</arguments>
             </configuration>
           </execution>
 
@@ -89,51 +60,16 @@
             <goals>
               <goal>grunt</goal>
             </goals>
+            <phase>generate-resources</phase>
             <configuration>
-              <!-- TODO(Anthony) : remove force once all JSHint are fixed! -->
+              <!-- TODO(anthonycorbacho): remove force once all JSHint are fixed! -->
               <arguments>--no-color --force</arguments>
             </configuration>
           </execution>
           
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <configuration>
-          <failOnMissingWebXml>false</failOnMissingWebXml>
-        </configuration>
-      </plugin>
     </plugins>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>com.github.eirslett</groupId>
-                    <artifactId>frontend-maven-plugin</artifactId>
-                    <versionRange>[0.0.16,)</versionRange>
-                    <goals>
-                      <goal>npm</goal>
-                      <goal>install-node-and-npm</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 
   <properties>

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -90,7 +90,7 @@
               <goal>grunt</goal>
             </goals>
             <configuration>
-              <!-- TODO(Anthony) : remove --force once all JSHint are fixed! -->
+              <!-- TODO(Anthony) : remove force once all JSHint are fixed! -->
               <arguments>--no-color --force</arguments>
             </configuration>
           </execution>

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -75,24 +75,25 @@
           </execution>
           
           <execution>
-			<id>bower install</id>
-			<goals>
-				<goal>bower</goal>
-			</goals>
-			<configuration>
-				<arguments>install</arguments>
-			</configuration>
-		  </execution>
+            <id>bower install</id>
+            <goals>
+              <goal>bower</goal>
+            </goals>
+            <configuration>
+              <arguments>install</arguments>
+            </configuration>
+          </execution>
 
-		  <execution>
-			<id>grunt build</id>
-			<goals>
-				<goal>grunt</goal>
-			</goals>
-			<configuration>
-				<arguments>--no-color --force</arguments>
-			</configuration>
-		  </execution>
+          <execution>
+            <id>grunt build</id>
+            <goals>
+              <goal>grunt</goal>
+            </goals>
+            <configuration>
+              <!-- TODO(Anthony) : remove --force once all JSHint are fixed! -->
+              <arguments>--no-color --force</arguments>
+            </configuration>
+          </execution>
           
         </executions>
       </plugin>

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -50,7 +50,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>0.0.16</version>
+        <version>0.0.20</version>
         <executions>
           <execution>
             <id>install node and npm</id>
@@ -65,19 +65,7 @@
           </execution>
 
           <execution>
-            <id>npm install ansi-color</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <configuration>
-              <arguments>install http://registry.npmjs.org/ansi-color/-/ansi-color-0.2.1.tgz</arguments>
-            </configuration>
-          </execution>
-
-          <execution>
             <id>npm install</id>
-            <phase>generate-sources</phase>
             <goals>
               <goal>npm</goal>
             </goals>
@@ -85,26 +73,28 @@
               <arguments>install</arguments>
             </configuration>
           </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <executions>
+          
           <execution>
-            <id>grunt-build-to-src-main-webapp</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
+			<id>bower install</id>
+			<goals>
+				<goal>bower</goal>
+			</goals>
+			<configuration>
+				<arguments>install</arguments>
+			</configuration>
+		  </execution>
+
+		  <execution>
+			<id>grunt build</id>
+			<goals>
+				<goal>grunt</goal>
+			</goals>
+			<configuration>
+				<arguments>--no-color --force</arguments>
+			</configuration>
+		  </execution>
+          
         </executions>
-        <configuration>
-          <executable>./grunt</executable>
-          <arguments>
-            <argument>build</argument>
-          </arguments>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR is about simplifying the pom (by updating the frontend-maven-plugin plugin) plus doesn't reinstall node, npm and bower components for every build.

Fix also the imagemin error `lib64/libc.so.6: version GLIBC_2.XX' not found` on Linux

