### PR TITLE
Final JsHint Fix

### DIFF
--- a/zeppelin-web/app/scripts/controllers/notebook.js
+++ b/zeppelin-web/app/scripts/controllers/notebook.js
@@ -1,4 +1,4 @@
-/* global confirm:false, alert:false */
+/* global confirm:false, alert:false, jQuery:false */
 /* jshint loopfunc: true */
 /* Copyright 2014 NFLabs
  *


### PR DESCRIPTION
## Bad Ass JsHint

For long time already, we are having problems with JsHint... Or should I say, with the fact that nobody is checking it out.

One of the reason is that JsHint is not running on build by default (because every warning is currently a blocker), and because of that, every pull request is adding to the long list of errors when we run `grunt jshint`

Since I am a bit tired of spending my time fixing other people JsHint errors, I decided to take care of it once and for all. (currently 96 errors)

In this pull request, we will try to fix and define multiple things related to JsHint:
- Having a JsHint configuration file
- Pushing confirm, alert, jQuery etc... to the JsHint configuration file
- Trying to have a warnings + errors system (warnings would not be a blocker)
- Define our JsHint rules, and which one are warnings or errors
- Having a Wiki page regarding JsHint
- Make JsHint run at every change on `grunt serve`
- Make JsHint run at every build (No fix, no build, no merge)
### For example:
- **'i' is already defined** should be an error
- **'config' is defined but never used.** should be a warning

--> Because it is always nice to keep every parameters in the callback functions, even if we don't use them
