### PR TITLE
Support for HiveContext

### DIFF
--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -25,6 +25,7 @@ import org.apache.spark.scheduler.ActiveJob;
 import org.apache.spark.scheduler.DAGScheduler;
 import org.apache.spark.scheduler.Stage;
 import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.hive.HiveContext;
 import org.apache.spark.ui.jobs.JobProgressListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,6 +83,7 @@ public class SparkInterpreter extends Interpreter {
   private SparkContext sc;
   private ByteArrayOutputStream out;
   private SQLContext sqlc;
+  private HiveContext hiveContext;
   private DependencyResolver dep;
   private SparkJLineCompletion completor;
 
@@ -112,6 +114,13 @@ public class SparkInterpreter extends Interpreter {
       sqlc = new SQLContext(getSparkContext());
     }
     return sqlc;
+  }
+
+  public HiveContext getHiveContext() {
+    if (hiveContext == null) {
+      hiveContext = new HiveContext(getSparkContext());
+    }
+    return hiveContext;
   }
 
   public DependencyResolver getDependencyResolver() {
@@ -245,7 +254,7 @@ public class SparkInterpreter extends Interpreter {
 
     dep = getDependencyResolver();
 
-    z = new ZeppelinContext(sc, sqlc, null, dep, printStream);
+    z = new ZeppelinContext(sc, sqlc, getHiveContext(), null, dep, printStream);
 
     this.interpreter.loadFiles(settings);
 
@@ -253,6 +262,7 @@ public class SparkInterpreter extends Interpreter {
     binder = (Map<String, Object>) getValue("_binder");
     binder.put("sc", sc);
     binder.put("sqlc", sqlc);
+    binder.put("hiveContext", getHiveContext());
     binder.put("z", z);
     binder.put("out", printStream);
 
@@ -262,6 +272,8 @@ public class SparkInterpreter extends Interpreter {
                  + "_binder.get(\"sc\").asInstanceOf[org.apache.spark.SparkContext]");
     intp.interpret("@transient val sqlc = "
                  + "_binder.get(\"sqlc\").asInstanceOf[org.apache.spark.sql.SQLContext]");
+    intp.interpret("@transient val hiveContext = "
+        + "_binder.get(\"hiveContext\").asInstanceOf[org.apache.spark.sql.hive.HiveContext]");
     intp.interpret("import org.apache.spark.SparkContext._");
     intp.interpret("import sqlc._");
   }

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/ZeppelinContext.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/ZeppelinContext.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.SchemaRDD;
+import org.apache.spark.sql.hive.HiveContext;
 
 import scala.Tuple2;
 
@@ -29,10 +30,12 @@ public class ZeppelinContext {
   private InterpreterContext interpreterContext;
 
   public ZeppelinContext(SparkContext sc, SQLContext sql,
+      HiveContext hiveContext,
       InterpreterContext interpreterContext,
       DependencyResolver dep, PrintStream printStream) {
     this.sc = sc;
     this.sqlContext = sql;
+    this.hiveContext = hiveContext;
     this.interpreterContext = interpreterContext;
     this.dep = dep;
     this.out = printStream;
@@ -40,6 +43,7 @@ public class ZeppelinContext {
 
   public SparkContext sc;
   public SQLContext sqlContext;
+  public HiveContext hiveContext;
   private Setting form;
 
   public SchemaRDD sql(String sql) {
@@ -132,6 +136,9 @@ public class ZeppelinContext {
     } else {
       out.println("Unknown error");
     }
+  }
+
+  private void restartInterpreter() {
   }
 
   public InterpreterContext getInterpreterContext() {


### PR DESCRIPTION
#287 Addresses issue around HiveContext.

Since Zeppelin already ships all the dependency of HiveContext, there're no problem that user can manually creating and using it.
However, there're no way to use HiveContext in `%sql` interpreter.

This PR creates HiveContext and expose them. And let user select which context want to use in `%sql` interpreter, HiveContext or SqlContext by setting `zeppelin.spark.useHiveContext` interpreter parameter.

Interpreter setting to use HiveContext (default is false)
![image](https://cloud.githubusercontent.com/assets/1540981/5914743/96068a22-a63e-11e4-88db-25345ab3dd52.png)

Example of use
![image](https://cloud.githubusercontent.com/assets/1540981/5914797/2adc285a-a63f-11e4-8768-362a633e882a.png)

Ready to be merged