### PR TITLE
Improve spark interpreter parameter handling

### DIFF
--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -75,7 +75,7 @@ public class SparkInterpreter extends Interpreter {
                 getSystemDefault(null, "spark.executor.memory", "512m"),
                 "executor memory per worker instance. ex) 512m, 32g")
             .add("spark.cores.max",
-                getSystemDefault(null, "spark.cores.max", null),
+                getSystemDefault(null, "spark.cores.max", ""),
                 "total number of cores to use. Empty value uses all available core")
             .add("args", "", "spark commandline args").build());
 
@@ -147,17 +147,19 @@ public class SparkInterpreter extends Interpreter {
     conf.set("spark.scheduler.mode", "FAIR");
 
     Properties intpProperty = getProperty();
+
     for (Object k : intpProperty.keySet()) {
       String key = (String) k;
       if (key.startsWith("spark.")) {
-        Object value = intpProperty.get(k);
+        Object value = intpProperty.get(key);
         if (value != null
             && value instanceof String
             && !((String) value).trim().isEmpty()) {
-          conf.set(key, intpProperty.getProperty(key));
+          conf.set(key, (String) value);
         }
       }
     }
+
     SparkContext sparkContext = new SparkContext(conf);
     return sparkContext;
   }
@@ -174,7 +176,7 @@ public class SparkInterpreter extends Interpreter {
       }
     }
 
-    if (propertyName !=null && !propertyName.isEmpty()) {
+    if (propertyName != null && !propertyName.isEmpty()) {
       String propValue = System.getProperty(propertyName);
       if (propValue != null) {
         return propValue;

--- a/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/interpreter/Interpreter.java
+++ b/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/interpreter/Interpreter.java
@@ -39,7 +39,10 @@ public abstract class Interpreter {
         .findRegisteredInterpreterByClassName(getClassName()).getProperties();
     for (String k : defaultProperties.keySet()) {
       if (!p.contains(k)) {
-        p.put(k, defaultProperties.get(k).getDefaultValue());
+        String value = defaultProperties.get(k).getDefaultValue();
+        if (value != null) {
+          p.put(k, defaultProperties.get(k).getDefaultValue());
+        }
       }
     }
 


### PR DESCRIPTION
#235 Introduces new way of passing configuration parameter to spark.

However, it overrides parameters that defined in old way. 
ie. if user sets spark parameter in environment variable, like `export ZEPPELIN_JAVA_OPTS=-Dspark.cores.max=10` it's simply ignored.

To minimize user experience changes, this PR now reads those old settings and uses it as a default value  of new parameter setting, for next three parameters

"spark.master", "spark.executor.memory", "spark.cores.max"