### PR TITLE
Remove docs related part since zeppelin-docs module is removed

### DIFF
--- a/zeppelin-server/src/main/java/com/nflabs/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/com/nflabs/zeppelin/server/ZeppelinServer.java
@@ -70,11 +70,13 @@ public class ZeppelinServer extends Application {
 
     // Web UI
     final WebAppContext webApp = setupWebAppContext(conf);
-    final WebAppContext webAppSwagg = setupWebAppSwagger(conf);
+    //Below is commented since zeppelin-docs module is removed.
+    //final WebAppContext webAppSwagg = setupWebAppSwagger(conf);
 
     // add all handlers
     ContextHandlerCollection contexts = new ContextHandlerCollection();
-    contexts.setHandlers(new Handler[]{swagger, restApi, webApp, webAppSwagg});
+    //contexts.setHandlers(new Handler[]{swagger, restApi, webApp, webAppSwagg});
+    contexts.setHandlers(new Handler[]{swagger, restApi, webApp});
     jettyServer.setHandler(contexts);
 
     notebookServer.start();
@@ -241,7 +243,7 @@ public class ZeppelinServer extends Application {
    *
    * @return WebAppContext with swagger ui context
    */
-  private static WebAppContext setupWebAppSwagger(
+  /*private static WebAppContext setupWebAppSwagger(
       ZeppelinConfiguration conf) {
 
     WebAppContext webApp = new WebAppContext();
@@ -257,7 +259,7 @@ public class ZeppelinServer extends Application {
     // Bind swagger-ui to the path HOST/docs
     webApp.addServlet(new ServletHolder(new DefaultServlet()), "/docs/*");
     return webApp;
-  }
+  }*/
 
   public ZeppelinServer() throws Exception {
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();


### PR DESCRIPTION
#289 PR occured below warning.
java.io.FileNotFoundException: /Users/zeppelin/zeppelin-server/../zeppelin-docs/src/main/swagger
This PR fixes it by removing docs related part.