### PR TITLE
Enable multiple SparkSQL execution concurrently

### DIFF
--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -23,6 +23,7 @@ import org.apache.spark.repl.SparkIMain;
 import org.apache.spark.repl.SparkJLineCompletion;
 import org.apache.spark.scheduler.ActiveJob;
 import org.apache.spark.scheduler.DAGScheduler;
+import org.apache.spark.scheduler.Pool;
 import org.apache.spark.scheduler.Stage;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.ui.jobs.JobProgressListener;
@@ -30,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import scala.Console;
+import scala.Enumeration.Value;
 import scala.None;
 import scala.Some;
 import scala.Tuple2;
@@ -262,6 +264,14 @@ public class SparkInterpreter extends Interpreter {
     completor = new SparkJLineCompletion(intp);
 
     sc = getSparkContext();
+    if (sc.getPoolForName("fair").isEmpty()) {
+      Value schedulingMode = org.apache.spark.scheduler.SchedulingMode.FAIR();
+      int minimumShare = 0;
+      int weight = 1;
+      Pool pool = new Pool("fair", schedulingMode, minimumShare, weight);
+      sc.taskScheduler().rootPool().addSchedulable(pool);
+    }
+
     sqlc = getSQLContext();
 
     dep = getDependencyResolver();

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
@@ -121,6 +121,8 @@ public class SparkSqlInterpreter extends Interpreter {
     SparkContext sc = sqlc.sparkContext();
     if (concurrentSQL()) {
       sc.setLocalProperty("spark.scheduler.pool", "fair");
+    } else {
+      sc.setLocalProperty("spark.scheduler.pool", null);
     }
 
     sc.setJobGroup(getJobGroup(context), "Zeppelin", false);

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
@@ -292,9 +292,12 @@ public class SparkSqlInterpreter extends Interpreter {
 
   @Override
   public Scheduler getScheduler() {
-    int maxConcurrency = 10;
-    return SchedulerFactory.singleton().createOrGetParallelScheduler(
-        SparkSqlInterpreter.class.getName() + this.hashCode(), maxConcurrency);
+    if (concurrentSQL()) {
+      int maxConcurrency = 10;
+      return SchedulerFactory.singleton().createOrGetParallelScheduler(
+          SparkSqlInterpreter.class.getName() + this.hashCode(), maxConcurrency);
+    }
+    return getSparkInterpreter().getScheduler();
   }
 
   @Override


### PR DESCRIPTION
This PR let user run multiple sql simultaneously.
But this feature is experimental, 
since it works fine only when there is one spark interpreter is bound to notes.
![2015-02-03 12 08 45](https://cloud.githubusercontent.com/assets/8503346/6002694/f13d9ee0-ab38-11e4-947c-297082aa9010.png)

Screen shot for multiple sql running
![2015-02-02 10 10 56](https://cloud.githubusercontent.com/assets/8503346/6002726/2f859338-ab39-11e4-8701-d9a4c4f5e4fe.png)
