### PR TITLE
Reliable dependency loading mechanism

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -48,7 +48,7 @@
 
 <property>
   <name>zeppelin.interpreters</name>
-  <value>com.nflabs.zeppelin.spark.SparkInterpreter,com.nflabs.zeppelin.spark.SparkSqlInterpreter,com.nflabs.zeppelin.markdown.Markdown,com.nflabs.zeppelin.shell.ShellInterpreter</value>
+  <value>com.nflabs.zeppelin.spark.SparkInterpreter,com.nflabs.zeppelin.spark.SparkSqlInterpreter,com.nflabs.zeppelin.spark.DepInterpreter,com.nflabs.zeppelin.markdown.Markdown,com.nflabs.zeppelin.shell.ShellInterpreter</value>
   <description>Comma separated interpreter configurations. First interpreter become a default</description>
 </property>
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
 		<parquet.version>1.4.3</parquet.version>
 		<jblas.version>1.2.3</jblas.version>
 		<jetty.version>8.1.14.v20131031</jetty.version>
+                <json4s.version>3.2.10</json4s.version>
 		<chill.version>0.3.6</chill.version>
 		<codahale.metrics.version>3.0.0</codahale.metrics.version>
 		<avro.version>1.7.6</avro.version>
@@ -793,6 +794,32 @@
 				<artifactId>jaxb-impl</artifactId>
 				<version>2.2.6</version>
 			</dependency>
+
+
+                        <!-- json4s -->
+                        <dependency>
+                                <groupId>org.json4s</groupId>
+                                <artifactId>json4s-core_2.10</artifactId>
+                                <version>${json4s.version}</version>
+                        </dependency>
+
+                        <dependency>
+                                <groupId>org.json4s</groupId>
+                                <artifactId>json4s-native_2.10</artifactId>
+                                <version>${json4s.version}</version>
+                        </dependency>
+
+                        <dependency>
+                                <groupId>org.json4s</groupId>
+                                <artifactId>json4s-jackson_2.10</artifactId>
+                                <version>${json4s.version}</version>
+                        </dependency>
+
+                        <dependency>
+                                <groupId>org.json4s</groupId>
+                                <artifactId>json4s-ext_2.10</artifactId>
+                                <version>${json4s.version}</version>
+	                </dependency>
 
 		</dependencies>
 	</dependencyManagement>

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/DepInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/DepInterpreter.java
@@ -1,0 +1,262 @@
+package com.nflabs.zeppelin.spark;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.spark.repl.SparkILoop;
+import org.apache.spark.repl.SparkIMain;
+import org.apache.spark.repl.SparkJLineCompletion;
+import org.sonatype.aether.resolution.ArtifactResolutionException;
+import org.sonatype.aether.resolution.DependencyResolutionException;
+
+import scala.Console;
+import scala.None;
+import scala.Some;
+import scala.tools.nsc.Settings;
+import scala.tools.nsc.interpreter.Completion.Candidates;
+import scala.tools.nsc.interpreter.Completion.ScalaCompleter;
+import scala.tools.nsc.settings.MutableSettings.BooleanSetting;
+import scala.tools.nsc.settings.MutableSettings.PathSetting;
+
+import com.nflabs.zeppelin.interpreter.Interpreter;
+import com.nflabs.zeppelin.interpreter.InterpreterContext;
+import com.nflabs.zeppelin.interpreter.InterpreterPropertyBuilder;
+import com.nflabs.zeppelin.interpreter.InterpreterResult;
+import com.nflabs.zeppelin.interpreter.InterpreterResult.Code;
+import com.nflabs.zeppelin.interpreter.WrappedInterpreter;
+import com.nflabs.zeppelin.scheduler.Scheduler;
+import com.nflabs.zeppelin.spark.dep.DependencyContext;
+
+
+/**
+ * DepInterpreter downloads dependencies and pass them when SparkInterpreter initialized.
+ * It extends SparkInterpreter but does not create sparkcontext
+ *
+ */
+public class DepInterpreter extends Interpreter {
+
+  static {
+    Interpreter.register(
+        "dep",
+        "spark",
+        DepInterpreter.class.getName(),
+        new InterpreterPropertyBuilder()
+            .build());
+
+  }
+
+  private SparkIMain intp;
+  private ByteArrayOutputStream out;
+  private DependencyContext depc;
+  private SparkJLineCompletion completor;
+  private SparkILoop interpreter;
+
+  public DepInterpreter(Properties property) {
+    super(property);
+  }
+
+  public DependencyContext getDependencyContext() {
+    return depc;
+  }
+
+
+  @Override
+  public void close() {
+    if (intp != null) {
+      intp.close();
+    }
+  }
+
+  @Override
+  public void open() {
+    out = new ByteArrayOutputStream();
+    createIMain();
+  }
+
+
+  private void createIMain() {
+    Settings settings = new Settings();
+    URL[] urls = getClassloaderUrls();
+
+    // set classpath for scala compiler
+    PathSetting pathSettings = settings.classpath();
+    String classpath = "";
+    List<File> paths = currentClassPath();
+    for (File f : paths) {
+      if (classpath.length() > 0) {
+        classpath += File.pathSeparator;
+      }
+      classpath += f.getAbsolutePath();
+    }
+
+    if (urls != null) {
+      for (URL u : urls) {
+        if (classpath.length() > 0) {
+          classpath += File.pathSeparator;
+        }
+        classpath += u.getFile();
+      }
+    }
+
+    pathSettings.v_$eq(classpath);
+    settings.scala$tools$nsc$settings$ScalaSettings$_setter_$classpath_$eq(pathSettings);
+
+    // set classloader for scala compiler
+    settings.explicitParentLoader_$eq(new Some<ClassLoader>(Thread.currentThread()
+        .getContextClassLoader()));
+
+    BooleanSetting b = (BooleanSetting) settings.usejavacp();
+    b.v_$eq(true);
+    settings.scala$tools$nsc$settings$StandardScalaSettings$_setter_$usejavacp_$eq(b);
+
+    interpreter = new SparkILoop(null, new PrintWriter(out));
+    interpreter.settings_$eq(settings);
+
+    interpreter.createInterpreter();
+
+
+    intp = interpreter.intp();
+    intp.setContextClassLoader();
+    intp.initializeSynchronous();
+
+    depc = new DependencyContext();
+    completor = new SparkJLineCompletion(intp);
+
+    intp.interpret("@transient var _binder = new java.util.HashMap[String, Object]()");
+    Map<String, Object> binder = (Map<String, Object>) getValue("_binder");
+    binder.put("depc", depc);
+
+    intp.interpret("@transient val z = "
+        + "_binder.get(\"depc\").asInstanceOf[com.nflabs.zeppelin.spark.dep.DependencyContext]");
+
+  }
+
+  @Override
+  public Object getValue(String name) {
+    Object ret = intp.valueOfTerm(name);
+    if (ret instanceof None) {
+      return null;
+    } else if (ret instanceof Some) {
+      return ((Some) ret).get();
+    } else {
+      return ret;
+    }
+  }
+
+  @Override
+  public InterpreterResult interpret(String st, InterpreterContext context) {
+    PrintStream printStream = new PrintStream(out);
+    Console.setOut(printStream);
+    out.reset();
+
+    scala.tools.nsc.interpreter.Results.Result ret = intp.interpret(st);
+    Code code = getResultCode(ret);
+
+    try {
+      depc.fetch();
+    } catch (MalformedURLException | DependencyResolutionException
+        | ArtifactResolutionException e) {
+      return new InterpreterResult(Code.ERROR, e.toString());
+    }
+
+    if (code == Code.INCOMPLETE) {
+      return new InterpreterResult(code, "Incomplete expression");
+    } else if (code == Code.ERROR) {
+      return new InterpreterResult(code, out.toString());
+    } else {
+      return new InterpreterResult(code, out.toString());
+    }
+  }
+
+  private Code getResultCode(scala.tools.nsc.interpreter.Results.Result r) {
+    if (r instanceof scala.tools.nsc.interpreter.Results.Success$) {
+      return Code.SUCCESS;
+    } else if (r instanceof scala.tools.nsc.interpreter.Results.Incomplete$) {
+      return Code.INCOMPLETE;
+    } else {
+      return Code.ERROR;
+    }
+  }
+
+  @Override
+  public void cancel(InterpreterContext context) {
+  }
+
+  @Override
+  public void bindValue(String name, Object o) {
+  }
+
+  @Override
+  public FormType getFormType() {
+    return null;
+  }
+
+  @Override
+  public int getProgress(InterpreterContext context) {
+    return 0;
+  }
+
+  @Override
+  public List<String> completion(String buf, int cursor) {
+    ScalaCompleter c = completor.completer();
+    Candidates ret = c.complete(buf, cursor);
+    return scala.collection.JavaConversions.asJavaList(ret.candidates());
+  }
+
+  private List<File> currentClassPath() {
+    List<File> paths = classPath(Thread.currentThread().getContextClassLoader());
+    String[] cps = System.getProperty("java.class.path").split(File.pathSeparator);
+    if (cps != null) {
+      for (String cp : cps) {
+        paths.add(new File(cp));
+      }
+    }
+    return paths;
+  }
+
+  private List<File> classPath(ClassLoader cl) {
+    List<File> paths = new LinkedList<File>();
+    if (cl == null) {
+      return paths;
+    }
+
+    if (cl instanceof URLClassLoader) {
+      URLClassLoader ucl = (URLClassLoader) cl;
+      URL[] urls = ucl.getURLs();
+      if (urls != null) {
+        for (URL url : urls) {
+          paths.add(new File(url.getFile()));
+        }
+      }
+    }
+    return paths;
+  }
+
+  private SparkInterpreter getSparkInterpreter() {
+    for (Interpreter intp : getInterpreterGroup()){
+      if (intp.getClassName().equals(SparkInterpreter.class.getName())) {
+        Interpreter p = intp;
+        while (p instanceof WrappedInterpreter) {
+          p = ((WrappedInterpreter) p).getInnerInterpreter();
+        }
+        return (SparkInterpreter) p;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public Scheduler getScheduler() {
+    return getSparkInterpreter().getScheduler();
+  }
+
+}

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/DepInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/DepInterpreter.java
@@ -158,6 +158,12 @@ public class DepInterpreter extends Interpreter {
     Console.setOut(printStream);
     out.reset();
 
+    SparkInterpreter sparkInterpreter = getSparkInterpreter();
+    if (sparkInterpreter.isSparkContextInitialized()) {
+      return new InterpreterResult(Code.ERROR,
+          "Must be used before SparkInterpreter (%spark) initialized");
+    }
+
     scala.tools.nsc.interpreter.Results.Result ret = intp.interpret(st);
     Code code = getResultCode(ret);
 

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/DepInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/DepInterpreter.java
@@ -29,6 +29,7 @@ import scala.tools.nsc.settings.MutableSettings.PathSetting;
 
 import com.nflabs.zeppelin.interpreter.Interpreter;
 import com.nflabs.zeppelin.interpreter.InterpreterContext;
+import com.nflabs.zeppelin.interpreter.InterpreterGroup;
 import com.nflabs.zeppelin.interpreter.InterpreterPropertyBuilder;
 import com.nflabs.zeppelin.interpreter.InterpreterResult;
 import com.nflabs.zeppelin.interpreter.InterpreterResult.Code;
@@ -159,6 +160,10 @@ public class DepInterpreter extends Interpreter {
     out.reset();
 
     SparkInterpreter sparkInterpreter = getSparkInterpreter();
+    if (sparkInterpreter == null) {
+      return new InterpreterResult(Code.ERROR,
+          "Must be used with SparkInterpreter");
+    }
     if (sparkInterpreter.isSparkContextInitialized()) {
       return new InterpreterResult(Code.ERROR,
           "Must be used before SparkInterpreter (%spark) initialized");
@@ -248,7 +253,11 @@ public class DepInterpreter extends Interpreter {
   }
 
   private SparkInterpreter getSparkInterpreter() {
-    for (Interpreter intp : getInterpreterGroup()){
+    InterpreterGroup intpGroup = getInterpreterGroup();
+    if (intpGroup == null) {
+      return null;
+    }
+    for (Interpreter intp : intpGroup){
       if (intp.getClassName().equals(SparkInterpreter.class.getName())) {
         Interpreter p = intp;
         while (p instanceof WrappedInterpreter) {

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -46,6 +46,7 @@ import scala.tools.nsc.settings.MutableSettings.PathSetting;
 
 import com.nflabs.zeppelin.interpreter.Interpreter;
 import com.nflabs.zeppelin.interpreter.InterpreterContext;
+import com.nflabs.zeppelin.interpreter.InterpreterGroup;
 import com.nflabs.zeppelin.interpreter.InterpreterPropertyBuilder;
 import com.nflabs.zeppelin.interpreter.InterpreterResult;
 import com.nflabs.zeppelin.interpreter.InterpreterResult.Code;
@@ -128,7 +129,9 @@ public class SparkInterpreter extends Interpreter {
   }
 
   private DepInterpreter getDepInterpreter() {
-    for (Interpreter intp : getInterpreterGroup()){
+    InterpreterGroup intpGroup = getInterpreterGroup();
+    if (intpGroup == null) return null;
+    for (Interpreter intp : intpGroup) {
       if (intp.getClassName().equals(DepInterpreter.class.getName())) {
         Interpreter p = intp;
         while (p instanceof WrappedInterpreter) {

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -109,6 +109,10 @@ public class SparkInterpreter extends Interpreter {
     return sc;
   }
 
+  public boolean isSparkContextInitialized() {
+    return sc != null;
+  }
+
   public SQLContext getSQLContext() {
     if (sqlc == null) {
       sqlc = new SQLContext(getSparkContext());

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/ZeppelinContext.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/ZeppelinContext.java
@@ -60,19 +60,7 @@ public class ZeppelinContext {
    * @throws Exception
    */
   public Iterable<String> load(String artifact) throws Exception {
-    return collectionAsScalaIterable(dep.load(artifact, false, false));
-  }
-
-  /**
-   * Load dependency for interpreter and runtime (driver).
-   *
-   * @param artifact "groupId:artifactId:version" or file path like "/somepath/your.jar"
-   * @param recursive load all transitive dependency when it is true
-   * @return
-   * @throws Exception
-   */
-  public Iterable<String> load(String artifact, boolean recursive) throws Exception {
-    return collectionAsScalaIterable(dep.load(artifact, recursive, false));
+    return collectionAsScalaIterable(dep.load(artifact, false));
   }
 
   /**
@@ -88,7 +76,6 @@ public class ZeppelinContext {
     return collectionAsScalaIterable(
         dep.load(artifact,
         asJavaCollection(excludes),
-        true,
         false));
   }
 
@@ -101,7 +88,7 @@ public class ZeppelinContext {
    * @throws Exception
    */
   public Iterable<String> load(String artifact, Collection<String> excludes) throws Exception {
-    return collectionAsScalaIterable(dep.load(artifact, excludes, true, false));
+    return collectionAsScalaIterable(dep.load(artifact, excludes, false));
   }
 
   /**
@@ -112,19 +99,9 @@ public class ZeppelinContext {
    * @throws Exception
    */
   public Iterable<String> loadAndDist(String artifact) throws Exception {
-    return collectionAsScalaIterable(dep.load(artifact, false, true));
+    return collectionAsScalaIterable(dep.load(artifact, true));
   }
 
-  /**
-   * Load dependency for interpreter and runtime, and then add to sparkContext
-   * @param artifact "groupId:artifactId:version" or file path like "/somepath/your.jar"
-   * @param recursive load all transitive dependency when it is true
-   * @return
-   * @throws Exception
-   */
-  public Iterable<String> loadAndDist(String artifact, boolean recursive) throws Exception {
-    return collectionAsScalaIterable(dep.load(artifact, true, true));
-  }
 
   /**
    * Load dependency and it's transitive dependencies and then add to sparkContext.
@@ -137,7 +114,7 @@ public class ZeppelinContext {
   public Iterable<String> loadAndDist(String artifact,
       scala.collection.Iterable<String> excludes) throws Exception {
     return collectionAsScalaIterable(dep.load(artifact,
-        asJavaCollection(excludes), true, true));
+        asJavaCollection(excludes), true));
   }
 
   /**
@@ -150,7 +127,7 @@ public class ZeppelinContext {
    */
   public Iterable<String> loadAndDist(String artifact, Collection<String> excludes)
       throws Exception {
-    return collectionAsScalaIterable(dep.load(artifact, excludes, true, true));
+    return collectionAsScalaIterable(dep.load(artifact, excludes, true));
   }
 
 

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/ZeppelinContext.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/ZeppelinContext.java
@@ -54,17 +54,19 @@ public class ZeppelinContext {
 
   /**
    * Load dependency for interpreter and runtime (driver).
+   * And distribute them to spark cluster (sc.add())
    *
    * @param artifact "group:artifact:version" or file path like "/somepath/your.jar"
    * @return
    * @throws Exception
    */
   public Iterable<String> load(String artifact) throws Exception {
-    return collectionAsScalaIterable(dep.load(artifact, false));
+    return collectionAsScalaIterable(dep.load(artifact, true));
   }
 
   /**
    * Load dependency and it's transitive dependencies for interpreter and runtime (driver).
+   * And distribute them to spark cluster (sc.add())
    *
    * @param artifact "groupId:artifactId:version" or file path like "/somepath/your.jar"
    * @param excludes exclusion list of transitive dependency. list of "groupId:artifactId" string.
@@ -76,11 +78,12 @@ public class ZeppelinContext {
     return collectionAsScalaIterable(
         dep.load(artifact,
         asJavaCollection(excludes),
-        false));
+        true));
   }
 
   /**
    * Load dependency and it's transitive dependencies for interpreter and runtime (driver).
+   * And distribute them to spark cluster (sc.add())
    *
    * @param artifact "groupId:artifactId:version" or file path like "/somepath/your.jar"
    * @param excludes exclusion list of transitive dependency. list of "groupId:artifactId" string.
@@ -88,46 +91,49 @@ public class ZeppelinContext {
    * @throws Exception
    */
   public Iterable<String> load(String artifact, Collection<String> excludes) throws Exception {
-    return collectionAsScalaIterable(dep.load(artifact, excludes, false));
+    return collectionAsScalaIterable(dep.load(artifact, excludes, true));
   }
 
   /**
    * Load dependency for interpreter and runtime, and then add to sparkContext.
+   * But not adding them to spark cluster
    *
    * @param artifact "groupId:artifactId:version" or file path like "/somepath/your.jar"
    * @return
    * @throws Exception
    */
-  public Iterable<String> loadAndDist(String artifact) throws Exception {
-    return collectionAsScalaIterable(dep.load(artifact, true));
+  public Iterable<String> loadLocal(String artifact) throws Exception {
+    return collectionAsScalaIterable(dep.load(artifact, false));
   }
 
 
   /**
    * Load dependency and it's transitive dependencies and then add to sparkContext.
+   * But not adding them to spark cluster
    *
    * @param artifact "groupId:artifactId:version" or file path like "/somepath/your.jar"
    * @param excludes exclusion list of transitive dependency. list of "groupId:artifactId" string.
    * @return
    * @throws Exception
    */
-  public Iterable<String> loadAndDist(String artifact,
+  public Iterable<String> loadLocal(String artifact,
       scala.collection.Iterable<String> excludes) throws Exception {
     return collectionAsScalaIterable(dep.load(artifact,
-        asJavaCollection(excludes), true));
+        asJavaCollection(excludes), false));
   }
 
   /**
    * Load dependency and it's transitive dependencies and then add to sparkContext.
+   * But not adding them to spark cluster
    *
    * @param artifact "groupId:artifactId:version" or file path like "/somepath/your.jar"
    * @param excludes exclusion list of transitive dependency. list of "groupId:artifactId" string.
    * @return
    * @throws Exception
    */
-  public Iterable<String> loadAndDist(String artifact, Collection<String> excludes)
+  public Iterable<String> loadLocal(String artifact, Collection<String> excludes)
       throws Exception {
-    return collectionAsScalaIterable(dep.load(artifact, excludes, true));
+    return collectionAsScalaIterable(dep.load(artifact, excludes, false));
   }
 
 
@@ -137,8 +143,8 @@ public class ZeppelinContext {
    * @param id id of repository ex) oss, local, snapshot
    * @param url url of repository. supported protocol : file, http, https
    */
-  public void addMavenRepo(String id, String url) {
-    addMavenRepo(id, url, false);
+  public void addRepo(String id, String url) {
+    addRepo(id, url, false);
   }
 
   /**
@@ -148,7 +154,7 @@ public class ZeppelinContext {
    * @param url url of repository. supported protocol : file, http, https
    * @param snapshot true if it is snapshot repository
    */
-  public void addMavenRepo(String id, String url, boolean snapshot) {
+  public void addRepo(String id, String url, boolean snapshot) {
     dep.addRepo(id, url, snapshot);
   }
 
@@ -156,7 +162,7 @@ public class ZeppelinContext {
    * Remove maven repository by id
    * @param id id of repository
    */
-  public void removeMavenRepo(String id){
+  public void removeRepo(String id){
     dep.delRepo(id);
   }
 

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/dep/Dependency.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/dep/Dependency.java
@@ -73,8 +73,8 @@ public class Dependency {
   }
 
   public boolean isLocalFsArtifact() {
-    return groupArtifactVersion.split(":").length != 3;
+    int numSplits = groupArtifactVersion.split(":").length;
+    return !(numSplits >= 3 && numSplits <= 5);
   }
-
 
 }

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/dep/Dependency.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/dep/Dependency.java
@@ -9,7 +9,6 @@ import java.util.List;
 public class Dependency {
   private String groupArtifactVersion;
   private boolean dist = false;
-  private boolean recursive = false;
   private List<String> exclusions;
 
 
@@ -36,8 +35,8 @@ public class Dependency {
     return this;
   }
 
-  public Dependency recursive() {
-    recursive = true;
+  public Dependency excludeAll() {
+    exclude("*");
     return this;
   }
 
@@ -47,7 +46,6 @@ public class Dependency {
    * @return
    */
   public Dependency exclude(String exclusions) {
-    recursive();
     for (String item : exclusions.split(",|\n")) {
       this.exclusions.add(item);
     }
@@ -64,17 +62,12 @@ public class Dependency {
     return dist;
   }
 
-  public boolean isRecursive() {
-    return recursive;
-  }
-
   public List<String> getExclusions() {
     return exclusions;
   }
 
   public boolean isLocalFsArtifact() {
     int numSplits = groupArtifactVersion.split(":").length;
-    return !(numSplits >= 3 && numSplits <= 5);
+    return !(numSplits >= 3 && numSplits <= 6);
   }
-
 }

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/dep/Dependency.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/dep/Dependency.java
@@ -8,7 +8,7 @@ import java.util.List;
  */
 public class Dependency {
   private String groupArtifactVersion;
-  private boolean dist = false;
+  private boolean local = false;
   private List<String> exclusions;
 
 
@@ -27,11 +27,11 @@ public class Dependency {
   }
 
   /**
-   * Add artifact into SparkContext (sc.addJar())
+   * Don't add artifact into SparkContext (sc.addJar())
    * @return
    */
-  public Dependency dist() {
-    dist = true;
+  public Dependency local() {
+    local = true;
     return this;
   }
 
@@ -59,7 +59,7 @@ public class Dependency {
   }
 
   public boolean isDist() {
-    return dist;
+    return !local;
   }
 
   public List<String> getExclusions() {

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/dep/Dependency.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/dep/Dependency.java
@@ -1,0 +1,80 @@
+package com.nflabs.zeppelin.spark.dep;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ *
+ */
+public class Dependency {
+  private String groupArtifactVersion;
+  private boolean dist = false;
+  private boolean recursive = false;
+  private List<String> exclusions;
+
+
+  public Dependency(String groupArtifactVersion) {
+    this.groupArtifactVersion = groupArtifactVersion;
+    exclusions = new LinkedList<String>();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof Dependency)) {
+      return false;
+    } else {
+      return ((Dependency) o).groupArtifactVersion.equals(groupArtifactVersion);
+    }
+  }
+
+  /**
+   * Add artifact into SparkContext (sc.addJar())
+   * @return
+   */
+  public Dependency dist() {
+    dist = true;
+    return this;
+  }
+
+  public Dependency recursive() {
+    recursive = true;
+    return this;
+  }
+
+  /**
+   *
+   * @param exclusions comma or newline separated list of "groupId:ArtifactId"
+   * @return
+   */
+  public Dependency exclude(String exclusions) {
+    recursive();
+    for (String item : exclusions.split(",|\n")) {
+      this.exclusions.add(item);
+    }
+
+    return this;
+  }
+
+
+  public String getGroupArtifactVersion() {
+    return groupArtifactVersion;
+  }
+
+  public boolean isDist() {
+    return dist;
+  }
+
+  public boolean isRecursive() {
+    return recursive;
+  }
+
+  public List<String> getExclusions() {
+    return exclusions;
+  }
+
+  public boolean isLocalFsArtifact() {
+    return groupArtifactVersion.split(":").length != 3;
+  }
+
+
+}

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/dep/DependencyContext.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/dep/DependencyContext.java
@@ -29,12 +29,14 @@ public class DependencyContext {
   List<Dependency> dependencies = new LinkedList<Dependency>();
   List<Repository> repositories = new LinkedList<Repository>();
 
-  List<File> files;
-  List<File> filesDist;
+  List<File> files = new LinkedList<File>();
+  List<File> filesDist = new LinkedList<File>();
   private RepositorySystem system = Booter.newRepositorySystem();
   private RepositorySystemSession session = Booter.newRepositorySystemSession(system);
   private RemoteRepository mavenCentral = new RemoteRepository("central",
       "default", "http://repo1.maven.org/maven2/");
+  private RemoteRepository mavenLocal = new RemoteRepository("local",
+      "default", "file://" + System.getProperty("user.home") + "/.m2/repository");
 
   public Dependency load(String lib) {
     Dependency dep = new Dependency(lib);
@@ -52,6 +54,14 @@ public class DependencyContext {
     return rep;
   }
 
+  public void reset() {
+    dependencies = new LinkedList<Dependency>();
+    repositories = new LinkedList<Repository>();
+
+    files = new LinkedList<File>();
+    filesDist = new LinkedList<File>();
+  }
+
 
   /**
    * fetch all artifacts
@@ -62,8 +72,6 @@ public class DependencyContext {
    */
   public List<File> fetch() throws MalformedURLException,
       DependencyResolutionException, ArtifactResolutionException {
-    files = new LinkedList<File>();
-    filesDist = new LinkedList<File>();
 
     for (Dependency dep : dependencies) {
       if (!dep.isLocalFsArtifact()) {
@@ -100,6 +108,7 @@ public class DependencyContext {
           JavaScopes.COMPILE));
 
       collectRequest.addRepository(mavenCentral);
+      collectRequest.addRepository(mavenLocal);
       for (Repository repo : repositories) {
         RemoteRepository rr = new RemoteRepository(repo.getName(), "default", repo.getUrl());
         rr.setPolicy(repo.isSnapshot(), null);
@@ -115,6 +124,7 @@ public class DependencyContext {
       artifactRequest.setArtifact(artifact);
 
       artifactRequest.addRepository(mavenCentral);
+      artifactRequest.addRepository(mavenLocal);
       for (Repository repo : repositories) {
         RemoteRepository rr = new RemoteRepository(repo.getName(), "default", repo.getUrl());
         rr.setPolicy(repo.isSnapshot(), null);

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/dep/DependencyContext.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/dep/DependencyContext.java
@@ -1,0 +1,138 @@
+package com.nflabs.zeppelin.spark.dep;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.sonatype.aether.RepositorySystem;
+import org.sonatype.aether.RepositorySystemSession;
+import org.sonatype.aether.artifact.Artifact;
+import org.sonatype.aether.collection.CollectRequest;
+import org.sonatype.aether.graph.DependencyFilter;
+import org.sonatype.aether.repository.RemoteRepository;
+import org.sonatype.aether.resolution.ArtifactRequest;
+import org.sonatype.aether.resolution.ArtifactResolutionException;
+import org.sonatype.aether.resolution.ArtifactResult;
+import org.sonatype.aether.resolution.DependencyRequest;
+import org.sonatype.aether.resolution.DependencyResolutionException;
+import org.sonatype.aether.util.artifact.DefaultArtifact;
+import org.sonatype.aether.util.artifact.JavaScopes;
+import org.sonatype.aether.util.filter.DependencyFilterUtils;
+import org.sonatype.aether.util.filter.ExclusionsDependencyFilter;
+
+
+/**
+ *
+ */
+public class DependencyContext {
+  List<Dependency> dependencies = new LinkedList<Dependency>();
+  List<Repository> repositories = new LinkedList<Repository>();
+
+  List<File> files;
+  List<File> filesDist;
+  private RepositorySystem system = Booter.newRepositorySystem();
+  private RepositorySystemSession session = Booter.newRepositorySystemSession(system);
+  private RemoteRepository mavenCentral = new RemoteRepository("central",
+      "default", "http://repo1.maven.org/maven2/");
+
+  public Dependency load(String lib) {
+    Dependency dep = new Dependency(lib);
+
+    if (dependencies.contains(dep)) {
+      dependencies.remove(dep);
+    }
+    dependencies.add(dep);
+    return dep;
+  }
+
+  public Repository addRepo(String name) {
+    Repository rep = new Repository(name);
+    repositories.add(rep);
+    return rep;
+  }
+
+
+  /**
+   * fetch all artifacts
+   * @return
+   * @throws MalformedURLException
+   * @throws ArtifactResolutionException
+   * @throws DependencyResolutionException
+   */
+  public List<File> fetch() throws MalformedURLException,
+      DependencyResolutionException, ArtifactResolutionException {
+    files = new LinkedList<File>();
+    filesDist = new LinkedList<File>();
+
+    for (Dependency dep : dependencies) {
+      if (!dep.isLocalFsArtifact()) {
+        List<ArtifactResult> artifacts = fetchArtifactWithDep(dep);
+        for (ArtifactResult artifact : artifacts) {
+          if (dep.isDist()) {
+            filesDist.add(artifact.getArtifact().getFile());
+          }
+          files.add(artifact.getArtifact().getFile());
+        }
+      } else {
+        if (dep.isDist()) {
+          filesDist.add(new File(dep.getGroupArtifactVersion()));
+        }
+        files.add(new File(dep.getGroupArtifactVersion()));
+      }
+    }
+
+    return files;
+  }
+
+  private List<ArtifactResult> fetchArtifactWithDep(Dependency dep)
+      throws DependencyResolutionException, ArtifactResolutionException {
+    Artifact artifact = new DefaultArtifact(dep.getGroupArtifactVersion());
+
+    if (dep.isRecursive()) {
+      DependencyFilter classpathFlter = DependencyFilterUtils
+          .classpathFilter(JavaScopes.COMPILE);
+      ExclusionsDependencyFilter exclusionFilter = new ExclusionsDependencyFilter(
+          dep.getExclusions());
+
+      CollectRequest collectRequest = new CollectRequest();
+      collectRequest.setRoot(new org.sonatype.aether.graph.Dependency(artifact,
+          JavaScopes.COMPILE));
+
+      collectRequest.addRepository(mavenCentral);
+      for (Repository repo : repositories) {
+        RemoteRepository rr = new RemoteRepository(repo.getName(), "default", repo.getUrl());
+        rr.setPolicy(repo.isSnapshot(), null);
+        collectRequest.addRepository(rr);
+      }
+
+      DependencyRequest dependencyRequest = new DependencyRequest(collectRequest,
+          DependencyFilterUtils.andFilter(exclusionFilter, classpathFlter));
+
+      return system.resolveDependencies(session, dependencyRequest).getArtifactResults();
+    } else {
+      ArtifactRequest artifactRequest = new ArtifactRequest();
+      artifactRequest.setArtifact(artifact);
+
+      artifactRequest.addRepository(mavenCentral);
+      for (Repository repo : repositories) {
+        RemoteRepository rr = new RemoteRepository(repo.getName(), "default", repo.getUrl());
+        rr.setPolicy(repo.isSnapshot(), null);
+        artifactRequest.addRepository(rr);
+      }
+
+      ArtifactResult artifactResult = system.resolveArtifact(session, artifactRequest);
+      LinkedList<ArtifactResult> results = new LinkedList<ArtifactResult>();
+      results.add(artifactResult);
+      return results;
+    }
+  }
+
+  public List<File> getFiles() {
+    return files;
+  }
+
+  public List<File> getFilesDist() {
+    return filesDist;
+  }
+}

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/dep/DependencyResolver.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/dep/DependencyResolver.java
@@ -22,13 +22,12 @@ import org.sonatype.aether.collection.CollectRequest;
 import org.sonatype.aether.graph.Dependency;
 import org.sonatype.aether.graph.DependencyFilter;
 import org.sonatype.aether.repository.RemoteRepository;
-import org.sonatype.aether.resolution.ArtifactRequest;
 import org.sonatype.aether.resolution.ArtifactResult;
 import org.sonatype.aether.resolution.DependencyRequest;
 import org.sonatype.aether.util.artifact.DefaultArtifact;
 import org.sonatype.aether.util.artifact.JavaScopes;
 import org.sonatype.aether.util.filter.DependencyFilterUtils;
-import org.sonatype.aether.util.filter.ExclusionsDependencyFilter;
+import org.sonatype.aether.util.filter.PatternExclusionsDependencyFilter;
 
 import scala.Some;
 import scala.collection.IndexedSeq;
@@ -171,13 +170,13 @@ public class DependencyResolver {
         platform.classPath().context());
   }
 
-  public List<String> load(String artifact, boolean recursive,
+  public List<String> load(String artifact,
       boolean addSparkContext) throws Exception {
-    return load(artifact, new LinkedList<String>(), recursive, addSparkContext);
+    return load(artifact, new LinkedList<String>(), addSparkContext);
   }
 
   public List<String> load(String artifact, Collection<String> excludes,
-      boolean recursive, boolean addSparkContext) throws Exception {
+      boolean addSparkContext) throws Exception {
     if (StringUtils.isBlank(artifact)) {
       // Should throw here
       throw new RuntimeException("Invalid artifact to load");
@@ -185,8 +184,8 @@ public class DependencyResolver {
 
     // <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>
     int numSplits = artifact.split(":").length;
-    if (numSplits >= 3 && numSplits <= 5) {
-      return loadFromMvn(artifact, excludes, recursive, addSparkContext);
+    if (numSplits >= 3 && numSplits <= 6) {
+      return loadFromMvn(artifact, excludes, addSparkContext);
     } else {
       loadFromFs(artifact, addSparkContext);
       LinkedList<String> libs = new LinkedList<String>();
@@ -209,18 +208,14 @@ public class DependencyResolver {
   }
 
   private List<String> loadFromMvn(String artifact, Collection<String> excludes,
-      boolean recursive, boolean addSparkContext) throws Exception {
+      boolean addSparkContext) throws Exception {
     List<String> loadedLibs = new LinkedList<String>();
     Collection<String> allExclusions = new LinkedList<String>();
     allExclusions.addAll(excludes);
     allExclusions.addAll(Arrays.asList(exclusions));
 
     List<ArtifactResult> listOfArtifact;
-    if (recursive) {
-      listOfArtifact = getArtifactsWithDep(artifact, allExclusions);
-    } else {
-      listOfArtifact = getArtifact(artifact);
-    }
+    listOfArtifact = getArtifactsWithDep(artifact, allExclusions);
 
     Iterator<ArtifactResult> it = listOfArtifact.iterator();
     while (it.hasNext()) {
@@ -260,22 +255,6 @@ public class DependencyResolver {
     return loadedLibs;
   }
 
-  public List<ArtifactResult> getArtifact(String dependency) throws Exception {
-    Artifact artifact = new DefaultArtifact(dependency);
-    ArtifactRequest artifactRequest = new ArtifactRequest();
-    artifactRequest.setArtifact(artifact);
-    synchronized (repos) {
-      for (RemoteRepository repo : repos) {
-        artifactRequest.addRepository(repo);
-      }
-    }
-
-    ArtifactResult artifactResult = system.resolveArtifact(session, artifactRequest);
-    LinkedList<ArtifactResult> results = new LinkedList<ArtifactResult>();
-    results.add(artifactResult);
-    return results;
-  }
-
   /**
    *
    * @param dependency
@@ -285,9 +264,10 @@ public class DependencyResolver {
    */
   public List<ArtifactResult> getArtifactsWithDep(String dependency,
       Collection<String> excludes) throws Exception {
-    Artifact artifact = new DefaultArtifact(dependency);
+    Artifact artifact = new DefaultArtifact(inferScalaVersion(dependency));
     DependencyFilter classpathFlter = DependencyFilterUtils.classpathFilter( JavaScopes.COMPILE );
-    ExclusionsDependencyFilter exclusionFilter = new ExclusionsDependencyFilter(excludes);
+    PatternExclusionsDependencyFilter exclusionFilter =
+        new PatternExclusionsDependencyFilter(inferScalaVersion(excludes));
 
     CollectRequest collectRequest = new CollectRequest();
     collectRequest.setRoot(new Dependency(artifact, JavaScopes.COMPILE));
@@ -300,5 +280,53 @@ public class DependencyResolver {
     DependencyRequest dependencyRequest = new DependencyRequest(collectRequest,
         DependencyFilterUtils.andFilter(exclusionFilter, classpathFlter));
     return system.resolveDependencies(session, dependencyRequest).getArtifactResults();
+  }
+
+  public static Collection<String> inferScalaVersion(Collection<String> artifact) {
+    List<String> list = new LinkedList<String>();
+    for (String a : artifact) {
+      list.add(inferScalaVersion(a));
+    }
+    return list;
+  }
+
+  public static String inferScalaVersion(String artifact) {
+    int pos = artifact.indexOf(":");
+    if (pos < 0 || pos + 2 >= artifact.length()) {
+      // failed to infer
+      return artifact;
+    }
+
+    if (':' == artifact.charAt(pos + 1)) {
+      String restOfthem = "";
+      String versionSep = ":";
+
+      String groupId = artifact.substring(0, pos);
+      int nextPos = artifact.indexOf(":", pos + 2);
+      if (nextPos < 0) {
+        if (artifact.charAt(artifact.length() - 1) == '*') {
+          nextPos = artifact.length() - 1;
+          versionSep = "";
+          restOfthem = "*";
+        } else {
+          versionSep = "";
+          nextPos = artifact.length();
+        }
+      }
+
+      String artifactId = artifact.substring(pos + 2, nextPos);
+      if (nextPos < artifact.length()) {
+        if (!restOfthem.equals("*")) {
+          restOfthem = artifact.substring(nextPos + 1);
+        }
+      }
+
+      String [] version = scala.util.Properties.versionNumberString().split("[.]");
+      String scalaVersion = version[0] + "." + version[1];
+
+      return groupId + ":" + artifactId + "_" + scalaVersion + versionSep + restOfthem;
+    } else {
+      return artifact;
+    }
   }
 }

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/dep/DependencyResolver.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/dep/DependencyResolver.java
@@ -183,7 +183,9 @@ public class DependencyResolver {
       throw new RuntimeException("Invalid artifact to load");
     }
 
-    if (artifact.split(":").length == 3) {
+    // <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>
+    int numSplits = artifact.split(":").length;
+    if (numSplits >= 3 && numSplits <= 5) {
       return loadFromMvn(artifact, excludes, recursive, addSparkContext);
     } else {
       loadFromFs(artifact, addSparkContext);

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/dep/DependencyResolver.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/dep/DependencyResolver.java
@@ -72,6 +72,8 @@ public class DependencyResolver {
     this.global = intp.global();
     this.sc = sc;
     repos.add(Booter.newCentralRepository()); // add maven central
+    repos.add(new RemoteRepository("local", "default", "file://"
+        + System.getProperty("user.home") + "/.m2/repository"));
   }
 
   public void addRepo(String id, String url, boolean snapshot) {

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/dep/Repository.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/dep/Repository.java
@@ -1,0 +1,37 @@
+package com.nflabs.zeppelin.spark.dep;
+
+/**
+ *
+ *
+ */
+public class Repository {
+  private boolean snapshot = false;
+  private String name;
+  private String url;
+
+  public Repository(String name){
+    this.name = name;
+  }
+
+  public Repository url(String url) {
+    this.url = url;
+    return this;
+  }
+
+  public Repository snapshot() {
+    snapshot = true;
+    return this;
+  }
+
+  public boolean isSnapshot() {
+    return snapshot;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+}

--- a/spark/src/test/java/com/nflabs/zeppelin/spark/DepInterpreterTest.java
+++ b/spark/src/test/java/com/nflabs/zeppelin/spark/DepInterpreterTest.java
@@ -61,12 +61,12 @@ public class DepInterpreterTest {
   }
 
   @Test
-  public void testBasic() {
+  public void testDefault() {
+    dep.getDependencyContext().reset();
     InterpreterResult ret = dep.interpret("z.load(\"org.apache.commons:commons-csv:1.1\")", context);
     assertEquals(Code.SUCCESS, ret.code());
 
     assertEquals(1, dep.getDependencyContext().getFiles().size());
-    assertEquals(0, dep.getDependencyContext().getFilesDist().size());
+    assertEquals(1, dep.getDependencyContext().getFilesDist().size());
   }
-
 }

--- a/spark/src/test/java/com/nflabs/zeppelin/spark/DepInterpreterTest.java
+++ b/spark/src/test/java/com/nflabs/zeppelin/spark/DepInterpreterTest.java
@@ -1,5 +1,7 @@
 package com.nflabs.zeppelin.spark;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.util.Properties;
 
@@ -8,13 +10,16 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.nflabs.zeppelin.interpreter.InterpreterContext;
+import com.nflabs.zeppelin.interpreter.InterpreterGroup;
 import com.nflabs.zeppelin.interpreter.InterpreterResult;
+import com.nflabs.zeppelin.interpreter.InterpreterResult.Code;
 import com.nflabs.zeppelin.notebook.Paragraph;
 
 public class DepInterpreterTest {
   private DepInterpreter dep;
   private InterpreterContext context;
   private File tmpDir;
+  private SparkInterpreter repl;
 
   @Before
   public void setUp() throws Exception {
@@ -27,6 +32,11 @@ public class DepInterpreterTest {
 
     dep = new DepInterpreter(p);
     dep.open();
+
+    InterpreterGroup intpGroup = new InterpreterGroup();
+    intpGroup.add(new SparkInterpreter(p));
+    intpGroup.add(dep);
+    dep.setInterpreterGroup(intpGroup);
 
     context = new InterpreterContext(new Paragraph(null, null));
   }
@@ -52,11 +62,11 @@ public class DepInterpreterTest {
 
   @Test
   public void testBasic() {
-    //repl.interpret("z.load(\"org.apache.commons:commons-csv:1.1\")", context);
-    //assertEquals(InterpreterResult.Code.SUCCESS, repl.interpret("import org.apache.commons.csv.CSVFormat", context).code());
-
     InterpreterResult ret = dep.interpret("z.load(\"org.apache.commons:commons-csv:1.1\")", context);
-    System.out.println("ret="+ret.message());
+    assertEquals(Code.SUCCESS, ret.code());
+
+    assertEquals(1, dep.getDependencyContext().getFiles().size());
+    assertEquals(0, dep.getDependencyContext().getFilesDist().size());
   }
 
 }

--- a/spark/src/test/java/com/nflabs/zeppelin/spark/DepInterpreterTest.java
+++ b/spark/src/test/java/com/nflabs/zeppelin/spark/DepInterpreterTest.java
@@ -1,0 +1,62 @@
+package com.nflabs.zeppelin.spark;
+
+import java.io.File;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.nflabs.zeppelin.interpreter.InterpreterContext;
+import com.nflabs.zeppelin.interpreter.InterpreterResult;
+import com.nflabs.zeppelin.notebook.Paragraph;
+
+public class DepInterpreterTest {
+  private DepInterpreter dep;
+  private InterpreterContext context;
+  private File tmpDir;
+
+  @Before
+  public void setUp() throws Exception {
+    tmpDir = new File(System.getProperty("java.io.tmpdir") + "/ZeppelinLTest_" + System.currentTimeMillis());
+    System.setProperty("zeppelin.dep.localrepo", tmpDir.getAbsolutePath() + "/local-repo");
+
+    tmpDir.mkdirs();
+
+    Properties p = new Properties();
+
+    dep = new DepInterpreter(p);
+    dep.open();
+
+    context = new InterpreterContext(new Paragraph(null, null));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    dep.close();
+    delete(tmpDir);
+  }
+
+  private void delete(File file) {
+    if (file.isFile()) file.delete();
+    else if (file.isDirectory()) {
+      File[] files = file.listFiles();
+      if (files != null && files.length > 0) {
+        for (File f : files) {
+          delete(f);
+        }
+      }
+      file.delete();
+    }
+  }
+
+  @Test
+  public void testBasic() {
+    //repl.interpret("z.load(\"org.apache.commons:commons-csv:1.1\")", context);
+    //assertEquals(InterpreterResult.Code.SUCCESS, repl.interpret("import org.apache.commons.csv.CSVFormat", context).code());
+
+    InterpreterResult ret = dep.interpret("z.load(\"org.apache.commons:commons-csv:1.1\")", context);
+    System.out.println("ret="+ret.message());
+  }
+
+}

--- a/spark/src/test/java/com/nflabs/zeppelin/spark/dep/DependencyResolverTest.java
+++ b/spark/src/test/java/com/nflabs/zeppelin/spark/dep/DependencyResolverTest.java
@@ -1,0 +1,34 @@
+package com.nflabs.zeppelin.spark.dep;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class DependencyResolverTest {
+
+  @Test
+  public void testInferScalaVersion() {
+    String [] version = scala.util.Properties.versionNumberString().split("[.]");
+    String scalaVersion = version[0] + "." + version[1];
+
+    assertEquals("groupId:artifactId:version",
+        DependencyResolver.inferScalaVersion("groupId:artifactId:version"));
+    assertEquals("groupId:artifactId_" + scalaVersion + ":version",
+        DependencyResolver.inferScalaVersion("groupId::artifactId:version"));
+    assertEquals("groupId:artifactId:version::test",
+        DependencyResolver.inferScalaVersion("groupId:artifactId:version::test"));
+    assertEquals("*",
+        DependencyResolver.inferScalaVersion("*"));
+    assertEquals("groupId:*",
+        DependencyResolver.inferScalaVersion("groupId:*"));
+    assertEquals("groupId:artifactId*",
+        DependencyResolver.inferScalaVersion("groupId:artifactId*"));
+    assertEquals("groupId:artifactId_" + scalaVersion,
+        DependencyResolver.inferScalaVersion("groupId::artifactId"));
+    assertEquals("groupId:artifactId_" + scalaVersion + "*",
+        DependencyResolver.inferScalaVersion("groupId::artifactId*"));
+    assertEquals("groupId:artifactId_" + scalaVersion + ":*",
+        DependencyResolver.inferScalaVersion("groupId::artifactId:*"));
+  }
+
+}

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -83,14 +83,6 @@
       	  <artifactId>jackson-module-scala_2.10</artifactId>
 	</exclusion>
 	<exclusion>
-      	  <groupId>org.json4s</groupId>
-      	  <artifactId>json4s-jackson_2.10</artifactId>
-	</exclusion>
-	<exclusion>
-      	  <groupId>org.json4s</groupId>
-      	  <artifactId>json4s-core_2.10</artifactId>
-	</exclusion>
-	<exclusion>
       	  <groupId>com.thoughtworks.paranamer</groupId>
       	  <artifactId>paranamer</artifactId>
 	</exclusion>

--- a/zeppelin-server/src/test/java/com/nflabs/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/com/nflabs/zeppelin/rest/ZeppelinRestApiTest.java
@@ -62,7 +62,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     assertThat(get, isAllowed());
     Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(), new TypeToken<Map<String, Object>>(){}.getType());
     Map<String, Object> body = (Map<String, Object>) resp.get("body");
-    assertEquals(4, body.size());
+    assertEquals(5, body.size());
     get.releaseConnection();
   }
 

--- a/zeppelin-web/app/scripts/controllers/interpreter.js
+++ b/zeppelin-web/app/scripts/controllers/interpreter.js
@@ -121,7 +121,7 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
       return;
     }
 
-    $http.get(getRestApiBase()+"/interpreter/setting/restart/"+settingId).
+    $http.put(getRestApiBase()+"/interpreter/setting/restart/"+settingId).
       success(function(data, status, headers, config) {
         for (var i=0; i < $scope.interpreterSettings.length; i++) {
           var setting = $scope.interpreterSettings[i];

--- a/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/conf/ZeppelinConfiguration.java
@@ -351,6 +351,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_API_WAR("zeppelin.api.war", "../zeppelin-docs/src/main/swagger"),
     ZEPPELIN_INTERPRETERS("zeppelin.interpreters", "com.nflabs.zeppelin.spark.SparkInterpreter,"
         + "com.nflabs.zeppelin.spark.SparkSqlInterpreter,"
+        + "com.nflabs.zeppelin.spark.DepInterpreter,"
         + "com.nflabs.zeppelin.markdown.Markdown,"
         + "com.nflabs.zeppelin.shell.ShellInterpreter"),
         ZEPPELIN_INTERPRETER_DIR("zeppelin.interpreter.dir", "interpreter"),


### PR DESCRIPTION
#308 Implements/fixes runtime dependency library loading. But the feature is unreliable so some library loaded correctly and some library not. 

While it looks not easy to find out reliable solution for runtime library loading, this PR trying to do library loading before SparkIMain being created, so library does not need to be loaded dynamically on runtime, but just included as a classpath. 

To do this, this PR adds an new interpreter, "DepInterpreter".
It provides separate scala interpreter and API to loads dependency. He is fetching necessary library from maven repository and keep the file list. And then when SparkInterpreter is initializing, it's passing that file list to SparkInterpreter, so SparkInterpreter adds them in the classpath without trying to load them on runtime.

* [x] DepInterpreter implementation
* [x] Warning message when DepInterpreter used after SparkInterpreter initialized.



Usage. DepInterpreter can be used with %dep expose instance of `com.nflabs.zeppelin.spark.dep.DependencyContext` as variable `z`.

Here's API
```
z.reset() // clean up previously added artifact and repository

// add maven repository
z.addRepo("RepoName").url("RepoURL")

// add maven snapshot repository
z.addRepo("RepoName").url("RepoURL").snapshot()

// add artifact from filesystem
z.load("/path/to.jar")

// add artifact from maven repository
z.load("groupId:artifactId:version")

// add artifact recursively (with all it's dependency)
z.load("groupId:artifactId:version").recursive()

// add artifact recursively except comma separated GroupID:ArtifactId list
z.load("groupId:artifactId:version").recursive().exclude("groupId:artifactId,groupId:artifactId, ...")

// add artifact recursively and distribute them to spark workers (sc.addJar())
z.load("groupId:artifactId:version").recursive().dist()
```


Example of use
![image](https://cloud.githubusercontent.com/assets/1540981/6059635/67b0e5d8-ad77-11e4-8c40-4f4b73af0556.png)

