### PR TITLE
Fix MultiEvent Catch in Zeppelin

### DIFF
--- a/zeppelin-web/app/scripts/controllers/main.js
+++ b/zeppelin-web/app/scripts/controllers/main.js
@@ -53,19 +53,19 @@ angular.module('zeppelinWebApp')
     if (event.data) {
       payload = angular.fromJson(event.data);
     }
-    console.log('Receive << %o, %o', payload.op, payload);
+    console.log('Receive << %o, %o, %o', payload.op, payload, $scope);
     var op = payload.op;
     var data = payload.data;
     if (op === 'NOTE') {
-      $rootScope.$emit('setNoteContent', data.note);
+      $scope.$broadcast('setNoteContent', data.note);
     } else if (op === 'NOTES_INFO') {
-      $rootScope.$emit('setNoteMenu', data.notes);
+      $scope.$broadcast('setNoteMenu', data.notes);
     } else if (op === 'PARAGRAPH') {
-      $rootScope.$emit('updateParagraph', data);
+      $scope.$broadcast('updateParagraph', data);
     } else if (op === 'PROGRESS') {
-      $rootScope.$emit('updateProgress', data);
+      $scope.$broadcast('updateProgress', data);
     } else if (op === 'COMPLETION_LIST') {
-      $rootScope.$emit('completionList', data);
+      $scope.$broadcast('completionList', data);
     }
   });
 
@@ -88,6 +88,7 @@ angular.module('zeppelinWebApp')
       WebSocket.send(JSON.stringify(data));
     }
   };
+
 
   /** get the childs event and sebd to the websocket server */
   $rootScope.$on('sendNewEvent', function(event, data) {

--- a/zeppelin-web/app/scripts/controllers/nav.js
+++ b/zeppelin-web/app/scripts/controllers/nav.js
@@ -1,3 +1,4 @@
+/* global $:false */
 /* Copyright 2014 NFLabs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +21,7 @@
  * @description
  * # NavCtrl
  * Controller of the top navigation, mainly use for the dropdown menu
- * 
+ *
  * @author anthonycorbacho
  */
 angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootScope, $routeParams) {
@@ -29,7 +30,7 @@ angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootSco
   $('#notebook-list').perfectScrollbar({suppressScrollX: true});
 
   /** Set the new menu */
-  $rootScope.$on('setNoteMenu', function(event, notes) {
+  $scope.$on('setNoteMenu', function(event, notes) {
       $scope.notes = notes;
   });
 
@@ -42,7 +43,7 @@ angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootSco
   $scope.createNewNote = function() {
     $rootScope.$emit('sendNewEvent', {op: 'NEW_NOTE'});
   };
-  
+
   /** Check if the note url is equal to the current note */
   $scope.isActive = function(noteId) {
     if ($routeParams.noteId === noteId) {
@@ -50,5 +51,5 @@ angular.module('zeppelinWebApp').controller('NavCtrl', function($scope, $rootSco
     }
     return false;
   };
-  
+
 });

--- a/zeppelin-web/app/scripts/controllers/notebook.js
+++ b/zeppelin-web/app/scripts/controllers/notebook.js
@@ -326,7 +326,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       for (var idx in newParagraphIds) {
         var newEntry = note.paragraphs[idx];
         if (oldParagraphIds[idx] === newParagraphIds[idx]) {
-          $rootScope.$emit('updateParagraph', {paragraph: newEntry});
+          $scope.$broadcast('updateParagraph', {paragraph: newEntry});
         } else {
           // move paragraph
           var oldIdx = oldParagraphIds.indexOf(newParagraphIds[idx]);

--- a/zeppelin-web/app/scripts/controllers/notebook.js
+++ b/zeppelin-web/app/scripts/controllers/notebook.js
@@ -78,42 +78,42 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   $scope.runNote = function() {
     var result = confirm('Run all paragraphs?');
     if (result) {
-      $rootScope.$emit('runParagraph');
+      $scope.$broadcast('runParagraph');
     }
   };
 
   $scope.toggleAllEditor = function() {
     if ($scope.editorToggled) {
-        $rootScope.$emit('closeEditor');
+      $scope.$broadcast('closeEditor');
     } else {
-        $rootScope.$emit('openEditor');
+      $scope.$broadcast('openEditor');
     }
     $scope.editorToggled = !$scope.editorToggled;
   };
 
   $scope.showAllEditor = function() {
-    $rootScope.$emit('openEditor');
+    $scope.$broadcast('openEditor');
   };
 
   $scope.hideAllEditor = function() {
-    $rootScope.$emit('closeEditor');
+    $scope.$broadcast('closeEditor');
   };
 
   $scope.toggleAllTable = function() {
     if ($scope.tableToggled) {
-        $rootScope.$emit('closeTable');
+      $scope.$broadcast('closeTable');
     } else {
-        $rootScope.$emit('openTable');
+      $scope.$broadcast('openTable');
     }
     $scope.tableToggled = !$scope.tableToggled;
   };
 
   $scope.showAllTable = function() {
-    $rootScope.$emit('openTable');
+    $scope.$broadcast('openTable');
   };
 
   $scope.hideAllTable = function() {
-    $rootScope.$emit('closeTable');
+    $scope.$broadcast('closeTable');
   };
 
   $scope.isNoteRunning = function() {
@@ -156,7 +156,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   };
 
   /** update the current note */
-  $rootScope.$on('setNoteContent', function(event, note) {
+  $scope.$on('setNoteContent', function(event, note) {
     $scope.paragraphUrl = $routeParams.paragraphId;
     $scope.asIframe = $routeParams.asIframe;
     if ($scope.paragraphUrl) {
@@ -209,7 +209,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     return noteCopy;
   };
 
-  $rootScope.$on('moveParagraphUp', function(event, paragraphId) {
+  $scope.$on('moveParagraphUp', function(event, paragraphId) {
     var newIndex = -1;
     for (var i=0; i<$scope.note.paragraphs.length; i++) {
       if ($scope.note.paragraphs[i].id === paragraphId) {
@@ -225,7 +225,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   });
 
   // create new paragraph on current position
-  $rootScope.$on('insertParagraph', function(event, paragraphId) {
+  $scope.$on('insertParagraph', function(event, paragraphId) {
     var newIndex = -1;
     for (var i=0; i<$scope.note.paragraphs.length; i++) {
       if ($scope.note.paragraphs[i].id === paragraphId) {
@@ -244,7 +244,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     $rootScope.$emit('sendNewEvent', { op: 'INSERT_PARAGRAPH', data : {index: newIndex}});
   });
 
-  $rootScope.$on('moveParagraphDown', function(event, paragraphId) {
+  $scope.$on('moveParagraphDown', function(event, paragraphId) {
     var newIndex = -1;
     for (var i=0; i<$scope.note.paragraphs.length; i++) {
       if ($scope.note.paragraphs[i].id === paragraphId) {
@@ -259,7 +259,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     $rootScope.$emit('sendNewEvent', { op: 'MOVE_PARAGRAPH', data : {id: paragraphId, index: newIndex}});
   });
 
-  $rootScope.$on('moveFocusToPreviousParagraph', function(event, currentParagraphId){
+  $scope.$on('moveFocusToPreviousParagraph', function(event, currentParagraphId){
     var focus = false;
     for (var i=$scope.note.paragraphs.length-1; i>=0; i--) {
       if (focus === false ) {
@@ -270,14 +270,14 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       } else {
         var p = $scope.note.paragraphs[i];
         if (!p.config.hide && !p.config.editorHide && !p.config.tableHide) {
-          $rootScope.$emit('focusParagraph', $scope.note.paragraphs[i].id);
+          $scope.$broadcast('focusParagraph', $scope.note.paragraphs[i].id);
           break;
         }
       }
     }
   });
 
-  $rootScope.$on('moveFocusToNextParagraph', function(event, currentParagraphId){
+  $scope.$on('moveFocusToNextParagraph', function(event, currentParagraphId){
     var focus = false;
     for (var i=0; i<$scope.note.paragraphs.length; i++) {
       if (focus === false ) {
@@ -288,7 +288,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       } else {
         var p = $scope.note.paragraphs[i];
         if (!p.config.hide && !p.config.editorHide && !p.config.tableHide) {
-          $rootScope.$emit('focusParagraph', $scope.note.paragraphs[i].id);
+          $scope.$broadcast('focusParagraph', $scope.note.paragraphs[i].id);
           break;
         }
       }

--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -131,7 +131,7 @@ angular.module('zeppelinWebApp')
   });
 
   // TODO: this may have impact on performance when there are many paragraphs in a note.
-  $rootScope.$on('updateParagraph', function(event, data) {
+  $scope.$on('updateParagraph', function(event, data) {
     if (data.paragraph.id === $scope.paragraph.id &&
          (
              data.paragraph.dateCreated !== $scope.paragraph.dateCreated ||
@@ -238,15 +238,15 @@ angular.module('zeppelinWebApp')
   };
 
   $scope.moveUp = function() {
-    $rootScope.$emit('moveParagraphUp', $scope.paragraph.id);
+    $scope.$emit('moveParagraphUp', $scope.paragraph.id);
   };
 
   $scope.moveDown = function() {
-    $rootScope.$emit('moveParagraphDown', $scope.paragraph.id);
+    $scope.$emit('moveParagraphDown', $scope.paragraph.id);
   };
 
   $scope.insertNew = function() {
-    $rootScope.$emit('insertParagraph', $scope.paragraph.id);
+    $scope.$emit('insertParagraph', $scope.paragraph.id);
   };
 
   $scope.removeParagraph = function() {
@@ -422,7 +422,7 @@ angular.module('zeppelinWebApp')
                   }
               });
 
-              $rootScope.$on('completionList', function(event, data) {
+              $scope.$on('completionList', function(event, data) {
                   if (data.completions) {
                       var completions = [];
                       for (var c in data.completions) {
@@ -514,14 +514,14 @@ angular.module('zeppelinWebApp')
                 currentRow = $scope.editor.getCursorPosition().row;
                 if (currentRow === 0) {
                     // move focus to previous paragraph
-                    $rootScope.$emit('moveFocusToPreviousParagraph', $scope.paragraph.id);
+                    $scope.$emit('moveFocusToPreviousParagraph', $scope.paragraph.id);
                 }
             } else if (keyCode === 40 || (keyCode === 78 && e.ctrlKey)) {  // DOWN
                 numRows = $scope.editor.getSession().getLength();
                 currentRow = $scope.editor.getCursorPosition().row;
                 if (currentRow === numRows-1) {
                     // move focus to next paragraph
-                    $rootScope.$emit('moveFocusToNextParagraph', $scope.paragraph.id);
+                    $scope.$emit('moveFocusToNextParagraph', $scope.paragraph.id);
                 }
             }
         }
@@ -551,36 +551,36 @@ angular.module('zeppelinWebApp')
     return 'Took ' + (timeMs/1000) + ' seconds';
   };
 
-  $rootScope.$on('updateProgress', function(event, data) {
+  $scope.$on('updateProgress', function(event, data) {
     if (data.id === $scope.paragraph.id) {
       $scope.currentProgress = data.progress;
     }
   });
 
-  $rootScope.$on('focusParagraph', function(event, paragraphId) {
+  $scope.$on('focusParagraph', function(event, paragraphId) {
     if ($scope.paragraph.id === paragraphId) {
       $scope.editor.focus();
       $('body').scrollTo('#'+paragraphId+'_editor', 300, {offset:-60});
     }
   });
 
-  $rootScope.$on('runParagraph', function(event) {
+  $scope.$on('runParagraph', function(event) {
     $scope.runParagraph($scope.editor.getValue());
   });
 
-  $rootScope.$on('openEditor', function(event) {
+  $scope.$on('openEditor', function(event) {
     $scope.openEditor();
   });
 
-  $rootScope.$on('closeEditor', function(event) {
+  $scope.$on('closeEditor', function(event) {
     $scope.closeEditor();
   });
 
-  $rootScope.$on('openTable', function(event) {
+  $scope.$on('openTable', function(event) {
     $scope.openTable();
   });
 
-  $rootScope.$on('closeTable', function(event) {
+  $scope.$on('closeTable', function(event) {
     $scope.closeTable();
   });
 


### PR DESCRIPTION
## Fixing MultiEvent Listener in Zeppelin

There was an annoying bug in zeppelin:

After moving from one note to another, Running the whole note, or adding new paragraph in a note would be done X times.

There is a simple reason related to angularJs: We have overused $rootScope.$on.

When a $rootScope.$on (Event Listener) is registered, it is registered with the $rootScope. Which means that even if the Controller was flushed after a changing page, the $rootScope is not destroy and the event listener is still register for the old Controller.

### How to Use Events in AngularJS/Zeppelin

* $rootScope.$on event listeners should only be used in MainCtrl which is the top of the App.
* Use $scope.$on for every other controllers to listen to Events
* Use $scope.$emit to send an event to a parent Controller (for example: paragraphCtrl to notebookCtrl)
* Use $scope.$broadcast to send an event to a child Controller (for example: notebookCtrl to paragraphCtrl)
* Use $rootScope.$emit to send an event to a controller that is not your parent (for example: paragraphCtrl to navCtrl), this event should be catch by the MainCtrl with a $rootScope.$on, then sent back to the rightful receiver using $scope.$broadcast.


#### Current ControllerStructure

```
MainCtrl: {
    NavCtrl,
    NotebookCtrl: [ paragraphCtrl, ...]
}
```