### PR TITLE
Injection of SparkContext in SparkInterperter 

### DIFF
--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -103,15 +103,27 @@ public class SparkInterpreter extends Interpreter {
     out = new ByteArrayOutputStream();
   }
 
+  public SparkInterpreter(Properties property, SparkContext sc) {
+    this(property);
+
+    this.sc = sc;
+    env = SparkEnv.get();
+    sparkListener = setupListeners(this.sc);
+  }
 
   public synchronized SparkContext getSparkContext() {
     if (sc == null) {
       sc = createSparkContext();
       env = SparkEnv.get();
-      sparkListener = new JobProgressListener(sc.getConf());
-      sc.listenerBus().addListener(sparkListener);
+      sparkListener = setupListeners(sc);
     }
     return sc;
+  }
+
+  private static JobProgressListener setupListeners(SparkContext context) {
+    JobProgressListener pl = new JobProgressListener(context.getConf());
+    context.listenerBus().addListener(pl);
+    return pl;
   }
 
   public SQLContext getSQLContext() {


### PR DESCRIPTION
To be able to use SparkInerperter from zeppelin-spark in third-party tests, which already manage SparkContext lifecycle it is useful to be able to inject it.
This PR adds an ability to do so though a new constructor.