### PR TITLE
Port is now retrieved by AppScriptServlet

### DIFF
--- a/zeppelin-web/app/scripts/app.js
+++ b/zeppelin-web/app/scripts/app.js
@@ -15,22 +15,35 @@
 
 'use strict';
 
-/** get the current port of the websocket
+/** Get the current port of the websocket
+  *
   * In the case of running the zeppelin-server normally,
-  * The body of this function is just filler. It will be dynamically
-  * overridden with the zeppelin-site.xml config value when the client
-  * requests the script. If the config value is not defined, it defaults
-  * to the HTTP port + 1
+  * the body of this function is just filler. It will be dynamically
+  * overridden with the AppScriptServlet from zeppelin-site.xml config value 
+  * when the client requests the script.
+  *
+  * If the config value is not defined, it defaults to the HTTP port + 1
   *
   * At the moment, the key delimiter denoting the end of this function
-  * during the replacement is the '}' character. Avoid using this
-  * character inside the function body
+  * during the replacement is the '}' character.
+  *
+  * !!!
+  * Avoid using '}' inside the function body or you will fail running
+  * in server mode.
+  * !!!
   *
   * In the case of running "grunt serve", this function will appear
   * as is.
   */
 function getPort() {
   var port = Number(location.port);
+  if (location.protocol !== 'https:' && (port === 'undifined' || port === 0))
+    port = 80;
+  else if (location.protocol === 'https:' && (port === 'undifined' || port === 0))
+    port = 443;
+  else if (port === 3333 || port === 9000)
+    port = 8080;
+  return port+1;
 }
 
 function getWebsocketProtocol() {

--- a/zeppelin-web/app/scripts/app.js
+++ b/zeppelin-web/app/scripts/app.js
@@ -31,14 +31,6 @@
   */
 function getPort() {
   var port = Number(location.port);
-  if (location.protocol !== 'https:' && (port === 'undifined' || port === 0)) {
-    port = 80;
-  } else if (location.protocol === 'https:' && (port === 'undifined' || port === 0)) {
-    port = 443;
-  } else if (port === 3333 || port === 9000) {
-    port = 8080;
-  }
-  return port+1;
 }
 
 function getWebsocketProtocol() {


### PR DESCRIPTION
The AppScriptServlet changes the content of app.js on the fly.
When I run vanilla zeppelin, I receive a blank page with a js error: `SyntaxError: syntax error function getPort(){return 8081} else if (location.protocol === 'https:' && (port...`
The changes simply removes the unneeded js code, leaving the server to the job for the port definition.
