### PR TITLE
spark sql interpreter should be able to open spark interpreter if spark interpreter is already not open

### DIFF
--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
@@ -76,11 +76,11 @@ public class SparkSqlInterpreter extends Interpreter {
     this.maxResult = conf.getInt("ZEPPELIN_SPARK_MAX_RESULT",
         "zeppelin.spark.maxResult",
         Integer.parseInt(getProperty("zeppelin.spark.maxResult")));
-    OpenSparkInterpreter(true);
+    openSparkInterpreter(true);
   }
 
   private SparkInterpreter getSparkInterpreter(){
-    return OpenSparkInterpreter(false);
+    return openSparkInterpreter(false);
   }
 
   private SparkInterpreter openSparkInterpreter(boolean open) {

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
@@ -76,20 +76,13 @@ public class SparkSqlInterpreter extends Interpreter {
     this.maxResult = conf.getInt("ZEPPELIN_SPARK_MAX_RESULT",
         "zeppelin.spark.maxResult",
         Integer.parseInt(getProperty("zeppelin.spark.maxResult")));
-    openSparkInterpreter(true);
   }
 
-  private SparkInterpreter getSparkInterpreter(){
-    return openSparkInterpreter(false);
-  }
-
-  private SparkInterpreter openSparkInterpreter(boolean open) {
-    for (Interpreter intp : getInterpreterGroup()){
+  private SparkInterpreter getSparkInterpreter() {
+    for (Interpreter intp : getInterpreterGroup()) {
       if (intp.getClassName().equals(SparkInterpreter.class.getName())) {
         Interpreter p = intp;
-        if (open == true) {
-          p.open();
-        }
+        p.open();
         while (p instanceof WrappedInterpreter) {
           p = ((WrappedInterpreter) p).getInnerInterpreter();
         }

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
@@ -33,6 +33,7 @@ import com.nflabs.zeppelin.interpreter.InterpreterPropertyBuilder;
 import com.nflabs.zeppelin.interpreter.InterpreterResult;
 import com.nflabs.zeppelin.interpreter.InterpreterResult.Code;
 import com.nflabs.zeppelin.interpreter.WrappedInterpreter;
+import com.nflabs.zeppelin.interpreter.LazyOpenInterpreter;
 import com.nflabs.zeppelin.scheduler.Scheduler;
 import com.nflabs.zeppelin.scheduler.SchedulerFactory;
 
@@ -82,8 +83,10 @@ public class SparkSqlInterpreter extends Interpreter {
     for (Interpreter intp : getInterpreterGroup()) {
       if (intp.getClassName().equals(SparkInterpreter.class.getName())) {
         Interpreter p = intp;
-        p.open();
         while (p instanceof WrappedInterpreter) {
+          if (p instanceof LazyOpenInterpreter) {
+            p.open();
+          }
           p = ((WrappedInterpreter) p).getInnerInterpreter();
         }
         return (SparkInterpreter) p;

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
@@ -76,13 +76,20 @@ public class SparkSqlInterpreter extends Interpreter {
     this.maxResult = conf.getInt("ZEPPELIN_SPARK_MAX_RESULT",
         "zeppelin.spark.maxResult",
         Integer.parseInt(getProperty("zeppelin.spark.maxResult")));
+    OpenSparkInterpreter(true);
   }
 
+  private SparkInterpreter getSparkInterpreter(){
+    return OpenSparkInterpreter(false);
+  }
 
-  private SparkInterpreter getSparkInterpreter() {
+  private SparkInterpreter openSparkInterpreter(boolean open) {
     for (Interpreter intp : getInterpreterGroup()){
       if (intp.getClassName().equals(SparkInterpreter.class.getName())) {
         Interpreter p = intp;
+        if (open == true) {
+          p.open();
+        }
         while (p instanceof WrappedInterpreter) {
           p = ((WrappedInterpreter) p).getInnerInterpreter();
         }

--- a/spark/src/test/java/com/nflabs/zeppelin/spark/SparkSqlInterpreterTest.java
+++ b/spark/src/test/java/com/nflabs/zeppelin/spark/SparkSqlInterpreterTest.java
@@ -35,12 +35,12 @@ public class SparkSqlInterpreterTest {
 		  }
 
   		sql = new SparkSqlInterpreter(p);
-		  sql.open();
 
   		InterpreterGroup intpGroup = new InterpreterGroup();
 		  intpGroup.add(repl);
 		  intpGroup.add(sql);
 		  sql.setInterpreterGroup(intpGroup);
+		  sql.open();
 		}
 		context = new InterpreterContext(new Paragraph(null, null));
 	}


### PR DESCRIPTION
If I try to use %sql as first command in notebook it errors out. But if I run sc.version first and the run %sql commands then things work fine. The PR fixes this issue....

Please review....