### PR TITLE
Single SparkContext parallelization

### DIFF
--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -204,50 +204,49 @@ public class SparkInterpreter extends Interpreter {
   public SparkContext createSparkContext() {
 
     // This synchronized statement on the class level is for the case when
-    // different threads call this method on different objects. It also deals
-    // with different threads calling this method on the same object
+    // different threads call this method on different objects.
     synchronized (getClass()) {
       if (singletonSparkContext != null) {
         return singletonSparkContext;
       }
-    }
 
-    System.err.println("------ Create new SparkContext " + getProperty("master") + " -------");
+      System.err.println("------ Create new SparkContext " + getProperty("master") + " -------");
 
-    String execUri = System.getenv("SPARK_EXECUTOR_URI");
-    String[] jars = SparkILoop.getAddedJars();
-    SparkConf conf =
-        new SparkConf()
-            .setMaster(getProperty("master"))
-            .setAppName(getProperty("spark.app.name"))
-            .setJars(jars)
-            .set("spark.repl.class.uri", interpreter.intp().classServer().uri());
+      String execUri = System.getenv("SPARK_EXECUTOR_URI");
+      String[] jars = SparkILoop.getAddedJars();
+      SparkConf conf =
+          new SparkConf()
+              .setMaster(getProperty("master"))
+              .setAppName(getProperty("spark.app.name"))
+              .setJars(jars)
+              .set("spark.repl.class.uri", interpreter.intp().classServer().uri());
 
-    if (execUri != null) {
-      conf.set("spark.executor.uri", execUri);
-    }
-    if (System.getenv("SPARK_HOME") != null) {
-      conf.setSparkHome(System.getenv("SPARK_HOME"));
-    }
+      if (execUri != null) {
+        conf.set("spark.executor.uri", execUri);
+      }
+      if (System.getenv("SPARK_HOME") != null) {
+        conf.setSparkHome(System.getenv("SPARK_HOME"));
+      }
 
-    conf.set("spark.scheduler.mode", "FAIR");
+      conf.set("spark.scheduler.mode", "FAIR");
 
-    Properties intpProperty = getProperty();
+      Properties intpProperty = getProperty();
 
-    for (Object k : intpProperty.keySet()) {
-      String key = (String) k;
-      if (key.startsWith("spark.")) {
-        Object value = intpProperty.get(key);
-        if (value != null
-            && value instanceof String
-            && !((String) value).trim().isEmpty()) {
-          conf.set(key, (String) value);
+      for (Object k : intpProperty.keySet()) {
+        String key = (String) k;
+        if (key.startsWith("spark.")) {
+          Object value = intpProperty.get(key);
+          if (value != null
+              && value instanceof String
+              && !((String) value).trim().isEmpty()) {
+            conf.set(key, (String) value);
+          }
         }
       }
-    }
 
-    SparkContext sparkContext = new SparkContext(conf);
-    return sparkContext;
+      singletonSparkContext = new SparkContext(conf);
+      return singletonSparkContext;
+    }
   }
 
   private static String getSystemDefault(

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -679,11 +679,12 @@ public class SparkInterpreter extends Interpreter {
     synchronized (getClass()) {
       numSparkContextHandles--;
       if (numSparkContextHandles == 0) {
-        sc.stop();
-        sc = null;
+        singletonSparkContext.stop();
+        singletonSparkContext = null;
       }
     }
 
+    sc = null;
     intp.close();
   }
 

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
@@ -119,8 +119,10 @@ public class SparkSqlInterpreter extends Interpreter {
     }
 
     SparkContext sc = sqlc.sparkContext();
+
+    String poolName = "fair_pool_" + getProperty("zeppelin.interpreter.name");
     if (concurrentSQL()) {
-      sc.setLocalProperty("spark.scheduler.pool", "fair");
+      sc.setLocalProperty("spark.scheduler.pool", poolName);
     } else {
       sc.setLocalProperty("spark.scheduler.pool", null);
     }

--- a/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/com/nflabs/zeppelin/interpreter/InterpreterFactory.java
@@ -125,6 +125,7 @@ public class InterpreterFactory {
 
             boolean found = false;
             Properties p = new Properties();
+            p.put("zeppelin.interpreter.name", groupName);
             for (RegisteredInterpreter info : infos) {
               if (found == false && info.getClassName().equals(className)) {
                 found = true;
@@ -195,6 +196,7 @@ public class InterpreterFactory {
       String group = (String) set.get("group");
       Properties properties = new Properties();
       properties.putAll((Map<String, String>) set.get("properties"));
+      properties.put("zeppelin.interpreter.name", name);
 
       InterpreterGroup interpreterGroup = createInterpreterGroup(group, properties);
       InterpreterSetting intpSetting = new InterpreterSetting(id, name, group, interpreterGroup);
@@ -203,7 +205,6 @@ public class InterpreterFactory {
 
     this.interpreterBindings = bindings;
   }
-
 
   private void saveToFile() throws IOException {
     String jsonString;


### PR DESCRIPTION
#331 

Using multiple SparkInterpreters causes an exception because each SparkInterpreter creates its own SparkContext, but there can't be more than 1 SparkContext in one JVM. This PR adds some logic to share a SparkContext by creating a pool for each SparkInterpreter. Ideally, each interpreter runs in its own JVM, but I see that's under consideration #278, so this is intended as a temporary workaround until that happens. 

There is one problem though. If multiple SparkInterpreters share the same SparkContext, it's not possible to close the SparkContext when closing one of the SparkInterpreters, so once a SparkContext is created, changes can't be made. Are there comments about how to best address this?