### PR TITLE
fix typo in zeppelin-env.sh.template

### DIFF
--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -5,7 +5,7 @@
 # export ZEPPELIN_JAVA_OPTS      # Additional jvm options. for example, export ZEPPELIN_JAVA_OPTS="-Dspark.executor.memory=8g -Dspark.cores.max=16"
 # export ZEPPELIN_MEM            # Zeppelin jvm mem options Default -Xmx1024m -XX:MaxPermSize=512m
 
-# export ZEPPELIN_CONF_DIR       # Alternate zeppelin conf dir. Default is ${HBASE_HOME}/conf.
+# export ZEPPELIN_CONF_DIR       # Alternate zeppelin conf dir. Default is ${ZEPPELIN_HOME}/conf.
 # export ZEPPELIN_LOG_DIR        # Where log files are stored.  PWD by default.
 # export ZEPPELIN_PID_DIR        # The pid files are stored. /tmp by default.
 # export ZEPPELIN_NOTEBOOK_DIR   # Where notebook saved


### PR DESCRIPTION
- HBASE_HOME to ZEPPELIN_HOME