### PR TITLE
interpret paragraph at once

### DIFF
--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -449,33 +449,27 @@ public class SparkInterpreter extends Interpreter {
    * Interpret a single line.
    */
   @Override
-  public InterpreterResult interpret(String line, InterpreterContext context) {
-    z.setInterpreterContext(context);
-    if (line == null || line.trim().length() == 0) {
-      return new InterpreterResult(Code.SUCCESS);
-    }
-    return interpret(line.split("\n"), context);
-  }
-
-  public InterpreterResult interpret(String[] lines, InterpreterContext context) {
+  public InterpreterResult interpret(String st, InterpreterContext context) {
     synchronized (this) {
+      z.setInterpreterContext(context);
+      if (st == null || st.trim().length() == 0) {
+        return new InterpreterResult(Code.SUCCESS);
+      }
+
       sc.setJobGroup(getJobGroup(context), "Zeppelin", false);
-      InterpreterResult r = interpretInput(lines);
+      InterpreterResult r = interpretInput(st);
       sc.clearJobGroup();
       return r;
     }
   }
-
-  public InterpreterResult interpretInput(String[] lines) {
+  
+  public InterpreterResult interpretInput(String st) {
     SparkEnv.set(env);
 
     // add print("") to make sure not finishing with comment
     // see https://github.com/NFLabs/zeppelin/issues/151
-    String[] linesToRun = new String[lines.length + 1];
-    for (int i = 0; i < lines.length; i++) {
-      linesToRun[i] = lines[i];
-    }
-    linesToRun[lines.length] = "print(\"\")";
+    String printEmptyString = "print(\"\")";
+    String[] linesToRun = new String[] {st, printEmptyString};
 
     Console.setOut((java.io.PrintStream) binder.get("out"));
     out.reset();
@@ -509,7 +503,6 @@ public class SparkInterpreter extends Interpreter {
       return new InterpreterResult(r, out.toString());
     }
   }
-
 
   @Override
   public void cancel(InterpreterContext context) {


### PR DESCRIPTION
This PR makes Spark interpreter run a paragraph at once. (Not splitting lines)
- faster when running long codes
- able to run line-splitted codes like this

![2015-03-10 6 35 55 pm](https://cloud.githubusercontent.com/assets/5210115/6572453/ba5c3830-c755-11e4-9448-9d8f9c27032a.png)
