### PR TITLE
Code Syntax Highlighting (take 2)

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -18,6 +18,8 @@ Call setTheme on the editor with the theme path/name.
 #### Style for Markdown Code Blocks
 Highlight.js parses and converts &lt;pre&gt;&lt;code&gt; blocks from markdown4j into keywords and language syntax with proper styles. It also attempts to infer the best fitting language if it is not provided. The visual style can be changed by simply including the desired [stylesheet](https://github.com/components/highlightjs/tree/master/styles) into app/index.html. See the next section on build.
 
+Note that code block background color is overriden in app/styles/notebook.css (look for .paragraph .tableDisplay .hljs).
+
 #### Build changes
 bower.json  
 In the override section at the bottom, include the Highlightjs stylesheet (eg. styles/github.css)  

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,0 +1,60 @@
+# Zeppelin Style Guide
+
+This is a quick guide on customizing style for the Zeppelin web interface (zeppelin-web)
+
+### Look and Feel
+app/styles/looknfeel  
+Overall look and theme of the Zeppelin notebook page can be customized here.
+
+### Code Syntax Highlighting
+There are two parts to code highlighting. First, Zeppelin uses the Ace Editor for its note paragraphs. Color style for this can be changed by setting theme on the editor instance. Second, Zeppelin's Markdown interpreter calls markdown4j to emit HTML, and such content may contain &lt;pre&gt;&lt;code&gt; tags that can be consumed by Highlight.js.
+
+#### Theme on Ace Editor
+app/scripts/controllers/paragraph.js  
+Call setTheme on the editor with the theme path/name.  
+[Setting Theme on Ace Documentation](http://ace.c9.io/#nav=howto)  
+[List of themes on GitHub](https://github.com/ajaxorg/ace/tree/master/lib/ace/theme)
+
+#### Style for Markdown Code Blocks
+Highlight.js parses and converts &lt;pre&gt;&lt;code&gt; blocks from markdown4j into keywords and language syntax with proper styles. It also attempts to infer the best fitting language if it is not provided. The visual style can be changed by simply including the desired [stylesheet](https://github.com/components/highlightjs/tree/master/styles) into app/index.html. See the next section on build.
+
+#### Build changes
+bower.json  
+In the override section at the bottom, include the Highlightjs stylesheet (eg. styles/github.css)  
+For the selected Ace Editor theme script, include it in the override section. (eg. src-noconflict/theme-github.js)  
+(bower will automatically add the appropriate .js and .css in app/index.html)
+```
+                  "src-noconflict/mode-sql.js",
+                  "src-noconflict/mode-markdown.js",
+                  "src-noconflict/keybinding-emacs.js",
+                 "src-noconflict/ext-language_tools.js",
++                 "src-noconflict/theme-github.js"],
+       "version": "1.1.8",
+       "name": "ace-builds"
+    },
+    "highlightjs": {
+        "main": ["highlight.pack.js",
++                 "styles/github.css"],
+      "version": "8.4.0",
+      "name": "highlightjs"
+     }
+```
+
+Gruntfile.js  
+Highlight.js style - depends on the style, a few themes have jpg - if so, one must copy them with Grunt.
+
+### Example - change Ace Editor theme to monokai
+
+app/scripts/controllers/paragraph.js
+```
+-      $scope.editor.setTheme('ace/theme/github');
++      $scope.editor.setTheme('ace/theme/monokai');
+```
+
+bower.json
+```
+-                 "src-noconflict/theme-github.js"],
++                 "src-noconflict/theme-monokai.js"],
+```
+
+Note that for certain themes, like monokai, with a dark background, you will need to update app/styles/notebook.css, .paragraphAsIframe .editor and .paragraph .editor for the background color.  

--- a/markdown/src/main/java/com/nflabs/zeppelin/markdown/Markdown.java
+++ b/markdown/src/main/java/com/nflabs/zeppelin/markdown/Markdown.java
@@ -49,7 +49,7 @@ public class Markdown extends Interpreter {
     String html;
     try {
       html = md.process(st);
-    } catch (IOException e) {
+    } catch (IOException | java.lang.RuntimeException e) {
       return new InterpreterResult(Code.ERROR, e.getMessage());
     }
     return new InterpreterResult(Code.SUCCESS, "%html " + html);

--- a/zeppelin-web/app/index.html
+++ b/zeppelin-web/app/index.html
@@ -36,6 +36,7 @@ limitations under the License.
     <link rel="stylesheet" href="bower_components/perfect-scrollbar/src/perfect-scrollbar.css" />
     <link rel="stylesheet" href="bower_components/ng-sortable/dist/ng-sortable.css" />
     <link rel="stylesheet" href="bower_components/angular-xeditable/dist/css/xeditable.css" />
+    <link rel="stylesheet" href="bower_components/highlightjs/styles/github.css" />
     <!-- endbower -->
     <link rel="stylesheet" href="bower_components/jquery-ui/themes/base/all.css" />
     <!-- endbuild -->
@@ -123,6 +124,7 @@ limitations under the License.
     <script src="bower_components/ace-builds/src-noconflict/mode-markdown.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/keybinding-emacs.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/ext-language_tools.js"></script>
+    <script src="bower_components/ace-builds/src-noconflict/theme-github.js"></script>
     <script src="bower_components/angular-ui-ace/ui-ace.js"></script>
     <script src="bower_components/jquery.scrollTo/jquery.scrollTo.js"></script>
     <script src="bower_components/d3/d3.js"></script>
@@ -134,6 +136,7 @@ limitations under the License.
     <script src="bower_components/angular-elastic/elastic.js"></script>
     <script src="bower_components/angular-elastic-input/dist/angular-elastic-input.min.js"></script>
     <script src="bower_components/angular-xeditable/dist/js/xeditable.js"></script>
+    <script src="bower_components/highlightjs/highlight.pack.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
     <!-- build:js({.tmp,app}) scripts/scripts.js -->

--- a/zeppelin-web/app/index.html
+++ b/zeppelin-web/app/index.html
@@ -124,7 +124,7 @@ limitations under the License.
     <script src="bower_components/ace-builds/src-noconflict/mode-markdown.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/keybinding-emacs.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/ext-language_tools.js"></script>
-    <script src="bower_components/ace-builds/src-noconflict/theme-monokai.js"></script>
+    <script src="bower_components/ace-builds/src-noconflict/theme-github.js"></script>
     <script src="bower_components/angular-ui-ace/ui-ace.js"></script>
     <script src="bower_components/jquery.scrollTo/jquery.scrollTo.js"></script>
     <script src="bower_components/d3/d3.js"></script>

--- a/zeppelin-web/app/index.html
+++ b/zeppelin-web/app/index.html
@@ -124,7 +124,7 @@ limitations under the License.
     <script src="bower_components/ace-builds/src-noconflict/mode-markdown.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/keybinding-emacs.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/ext-language_tools.js"></script>
-    <script src="bower_components/ace-builds/src-noconflict/theme-github.js"></script>
+    <script src="bower_components/ace-builds/src-noconflict/theme-monokai.js"></script>
     <script src="bower_components/angular-ui-ace/ui-ace.js"></script>
     <script src="bower_components/jquery.scrollTo/jquery.scrollTo.js"></script>
     <script src="bower_components/d3/d3.js"></script>

--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -65,6 +65,8 @@ angular.module('zeppelinWebApp')
       if ($('#p'+$scope.paragraph.id+'_html').length) {
         try {
           $('#p'+$scope.paragraph.id+'_html').html($scope.paragraph.result.msg);
+
+          $('#p'+$scope.paragraph.id+'_html').find('pre code').each(function(i, e) { hljs.highlightBlock(e) });
         } catch(err) {
           console.log('HTML rendering error %o', err);
         }
@@ -390,6 +392,7 @@ angular.module('zeppelinWebApp')
     if (_editor.container.id !== '{{paragraph.id}}_editor') {
       $scope.editor.renderer.setShowGutter(false);
       $scope.editor.setHighlightActiveLine(false);
+      $scope.editor.setTheme('ace/theme/github');
       $scope.editor.focus();
       var hight = $scope.editor.getSession().getScreenLength() * $scope.editor.renderer.lineHeight + $scope.editor.renderer.scrollBar.getWidth();
       setEditorHeight(_editor.container.id, hight);

--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -392,7 +392,7 @@ angular.module('zeppelinWebApp')
     if (_editor.container.id !== '{{paragraph.id}}_editor') {
       $scope.editor.renderer.setShowGutter(false);
       $scope.editor.setHighlightActiveLine(false);
-      $scope.editor.setTheme('ace/theme/github');
+      $scope.editor.setTheme('ace/theme/monokai');
       $scope.editor.focus();
       var hight = $scope.editor.getSession().getScreenLength() * $scope.editor.renderer.lineHeight + $scope.editor.renderer.scrollBar.getWidth();
       setEditorHeight(_editor.container.id, hight);

--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -392,7 +392,7 @@ angular.module('zeppelinWebApp')
     if (_editor.container.id !== '{{paragraph.id}}_editor') {
       $scope.editor.renderer.setShowGutter(false);
       $scope.editor.setHighlightActiveLine(false);
-      $scope.editor.setTheme('ace/theme/monokai');
+      $scope.editor.setTheme('ace/theme/github');
       $scope.editor.focus();
       var hight = $scope.editor.getSession().getScreenLength() * $scope.editor.renderer.lineHeight + $scope.editor.renderer.scrollBar.getWidth();
       setEditorHeight(_editor.container.id, hight);

--- a/zeppelin-web/app/styles/notebook.css
+++ b/zeppelin-web/app/styles/notebook.css
@@ -67,16 +67,12 @@
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
 }
 
-.ace-tm .ace_marker-layer .ace_selection {
-    background: rgba(98, 157, 233, 0.2) !important;
+.ace_marker-layer .ace_selection {
+    z-index: 0 !important;
 }
 
-.ace_active-line {
-    background: rgba(98, 157, 233, 0.2) !important;
-}
-
-.ace-tm .ace_marker-layer .ace_selected-word {
-    background: rgba(250, 250, 255, 0.2) !important;
+.ace_marker-layer .ace_selected-word {
+    z-index: 0 !important;
 }
 
 .labelBtn {

--- a/zeppelin-web/app/styles/notebook.css
+++ b/zeppelin-web/app/styles/notebook.css
@@ -51,6 +51,7 @@
 .paragraphAsIframe .editor {
   width: 100%;
   border-left: 4px solid #EEEEEE;
+  background: rgba(255, 255, 255, 0.9);
 }
 
 .paragraphAsIframe .text {
@@ -171,6 +172,7 @@
 .paragraph .editor {
   width: 100%;
   border-left: 4px solid #DDDDDD;
+  background: rgba(255, 255, 255, 0.0);
   margin: 7px 0 2px 0px;
 }
 

--- a/zeppelin-web/app/styles/notebook.css
+++ b/zeppelin-web/app/styles/notebook.css
@@ -69,7 +69,6 @@
 
 .ace-tm .ace_marker-layer .ace_selection {
     background: rgba(98, 157, 233, 0.2) !important;
-    color: black;
 }
 
 .ace_active-line {

--- a/zeppelin-web/app/styles/notebook.css
+++ b/zeppelin-web/app/styles/notebook.css
@@ -51,7 +51,6 @@
 .paragraphAsIframe .editor {
   width: 100%;
   border-left: 4px solid #EEEEEE;
-  background: rgba(255, 255, 255, 0.9);
 }
 
 .paragraphAsIframe .text {
@@ -172,7 +171,6 @@
 .paragraph .editor {
   width: 100%;
   border-left: 4px solid #DDDDDD;
-  background: rgba(255, 255, 255, 0.0);
   margin: 7px 0 2px 0px;
 }
 

--- a/zeppelin-web/app/styles/notebook.css
+++ b/zeppelin-web/app/styles/notebook.css
@@ -23,6 +23,14 @@
   min-height: 32px;
 }
 
+.paragraph .tableDisplay .hljs {
+  background: none;
+}
+
+.paragraph .ace_print-margin {
+  background: none !important;
+}
+
 .paragraphAsIframe{
   padding: 0px 0px 0px 0px;
   margin-top: -79px;
@@ -207,10 +215,6 @@
 }
 
 .ace_hidden-cursors {opacity:0}
-
-.ace-tm .ace_print-margin {
-  background: none !important;
-}
 
 /** Remove z-index to ace */
 .ace_text-input, .ace_gutter, .ace_layer,

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -22,7 +22,8 @@
     "ng-sortable": "~1.1.9",
     "angular-elastic": "~2.4.2",
     "angular-elastic-input": "~2.0.1",
-    "angular-xeditable" : "0.1.8"
+    "angular-xeditable" : "0.1.8",
+    "highlightjs": "~8.4.0"
   },
   "devDependencies": {
     "angular-mocks": "1.3.8",
@@ -39,9 +40,16 @@
                  "src-noconflict/mode-sql.js",
                  "src-noconflict/mode-markdown.js",
                  "src-noconflict/keybinding-emacs.js",
-                 "src-noconflict/ext-language_tools.js"],
+                 "src-noconflict/ext-language_tools.js",
+                 "src-noconflict/theme-github.js"],
       "version": "1.1.8",
       "name": "ace-builds"
+    },
+    "highlightjs": {
+        "main": ["highlight.pack.js",
+                 "styles/github.css"],
+      "version": "8.4.0",
+      "name": "highlightjs"
     }
   }
 }

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -41,7 +41,7 @@
                  "src-noconflict/mode-markdown.js",
                  "src-noconflict/keybinding-emacs.js",
                  "src-noconflict/ext-language_tools.js",
-                 "src-noconflict/theme-monokai.js"],
+                 "src-noconflict/theme-github.js"],
       "version": "1.1.8",
       "name": "ace-builds"
     },

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -41,7 +41,7 @@
                  "src-noconflict/mode-markdown.js",
                  "src-noconflict/keybinding-emacs.js",
                  "src-noconflict/ext-language_tools.js",
-                 "src-noconflict/theme-github.js"],
+                 "src-noconflict/theme-monokai.js"],
       "version": "1.1.8",
       "name": "ace-builds"
     },


### PR DESCRIPTION
#300 - continuing from where we left off. I ran into some very bad error with js and couldn't figure out how to make it not error out, so I finally gave up I started clean in a new branch.

This PR includes Markdown code block syntax highlighting and Ace Editor theme setting, as an example. It only set 1 theme (matching for now) for each.

Also detailing in documentation what's required if someone wants to change it.

Here's what it looks like:
![image](https://cloud.githubusercontent.com/assets/8969467/6591877/5552b0d0-c783-11e4-8466-5a55046a9295.png)

And here's 'what-if' if we are to change theme for the editor (but not markdown) This is not checked in. To be clear, no way to use this theme without changing code/build)
![image](https://cloud.githubusercontent.com/assets/8969467/6591895/90e63c20-c783-11e4-9891-90968b16dbc3.png)

Feedback appreciated.
