### PR TITLE
Support Hadoop 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Yarn (Hadoop 2.2.x and later)
 ```
 mvn clean package -Pspark-1.1 -Dhadoop.version=2.2.0 -Phadoop-2.2 -Pyarn -DskipTests
 ```
+Apache Bigtop (version 0.9+, Hadoop 2.6.0 and Spark 1.2.1)
+```
+mvn clean package -Pspark-1.2 -Dhadoop.version=2.6.0 -Phadoop-2.6 -DskipTests
+```
 
 ### Configure
 If you wish to configure Zeppelin option (like port number), configure the following files:

--- a/pom.xml
+++ b/pom.xml
@@ -1290,6 +1290,15 @@
 				<jets3t.version>0.9.0</jets3t.version>
 			</properties>
 		</profile>
+		
+		<profile>
+			<id>hadoop-2.6</id>
+			<properties>
+				<hadoop.version>2.6.0</hadoop.version>
+				<protobuf.version>2.5.0</protobuf.version>
+				<jets3t.version>0.9.0</jets3t.version>
+			</properties>
+		</profile>
 
                 <profile>
                         <id>mapr3</id>


### PR DESCRIPTION
With this patch, Building Zeppelin with Hadoop 2.6.0 and Spark 1.2.0 works fine on my end.