### PR TITLE
Support Spark 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Spark 1.2.x
 ```
 mvn clean package -Pspark-1.2 -Dhadoop.version=2.2.0 -Phadoop-2.2 -DskipTests 
 ```
+Spark 1.3.x
+```
+mvn clean package -Pspark-1.3 -Dhadoop.version=2.2.0 -Phadoop-2.2 -DskipTests
+```
 CDH 5.X
 ```
 mvn clean package -Pspark-1.2 -Dhadoop.version=2.5.0-cdh5.3.0 -Phadoop-2.4 -DskipTests

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ mvn clean package
 ```
 Build with specific version
 
-Spark 1.1.x (more stable with Zeppelin for this moment.)
+Spark 1.1.x
 ```
 mvn clean package -Pspark-1.1 -Dhadoop.version=2.2.0 -Phadoop-2.2 -DskipTests 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -1261,15 +1261,15 @@
                         <properties>
                                 <akka.version>2.3.4-spark</akka.version>
                                 <spark.version>1.3.0</spark.version>
-		                <mesos.version>0.21.0</mesos.version>
-		                <hbase.version>0.98.7</hbase.version>
-		                <hbase.artifact>hbase</hbase.artifact>
-		                <hive.group>org.spark-project.hive</hive.group>
-		                <hive.version>0.13.1a</hive.version>
+                                <mesos.version>0.21.0</mesos.version>
+                                <hbase.version>0.98.7</hbase.version>
+                                <hbase.artifact>hbase</hbase.artifact>
+                                <hive.group>org.spark-project.hive</hive.group>
+                                <hive.version>0.13.1a</hive.version>
                                 <derby.version>10.10.1.1</derby.version>
                                 <orbit.version>3.0.0.v201112011016</orbit.version>
-		                <parquet.version>1.6.0rc3</parquet.version>
-		                <chill.version>0.5.0</chill.version>
+                                <parquet.version>1.6.0rc3</parquet.version>
+                                <chill.version>0.5.0</chill.version>
                                 <ivy.version>2.4.0</ivy.version>
                                 <oro.version>2.0.8</oro.version>
                                 <avro.mapred.classifier></avro.mapred.classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,8 @@
 		<jets3t.version>0.7.1</jets3t.version>
                 <commons.math3.version>3.2</commons.math3.version>
                 <commons.httpclient.version>4.3.6</commons.httpclient.version>
+                <codehaus.jackson.version>1.8.8</codehaus.jackson.version>
+                <snappy.version>1.0.5</snappy.version>
                 <io.netty.version>4.0.17.Final</io.netty.version>
 
 		<guava.version>15.0</guava.version>
@@ -286,7 +288,7 @@
 			<dependency>
 				<groupId>org.xerial.snappy</groupId>
 				<artifactId>snappy-java</artifactId>
-				<version>1.0.5</version>
+				<version>${snappy.version}</version>
 			</dependency>
 
 			<dependency>
@@ -762,13 +764,13 @@
 				<!-- Matches the version of jackson-core-asl pulled in by avro -->
 				<groupId>org.codehaus.jackson</groupId>
 				<artifactId>jackson-mapper-asl</artifactId>
-				<version>1.8.8</version>
+				<version>${codehaus.jackson.version}</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.codehaus.jackson</groupId>
 				<artifactId>jackson-core-asl</artifactId>
-				<version>1.8.8</version>
+				<version>${codehaus.jackson.version}</version>
 			</dependency>
 
 			<dependency>
@@ -1249,6 +1251,35 @@
                                 <commons.httpclient.version>4.2.6</commons.httpclient.version>
                                 <commons.math3.version>3.1.1</commons.math3.version>
                                 <io.netty.version>4.0.23.Final</io.netty.version>
+                        </properties>
+                </profile>
+
+                <profile>
+                        <id>spark-1.3</id>
+                        <dependencies>
+                        </dependencies>
+                        <properties>
+                                <akka.version>2.3.4-spark</akka.version>
+                                <spark.version>1.3.0</spark.version>
+		                <mesos.version>0.21.0</mesos.version>
+		                <hbase.version>0.98.7</hbase.version>
+		                <hbase.artifact>hbase</hbase.artifact>
+		                <hive.group>org.spark-project.hive</hive.group>
+		                <hive.version>0.13.1a</hive.version>
+                                <derby.version>10.10.1.1</derby.version>
+                                <orbit.version>3.0.0.v201112011016</orbit.version>
+		                <parquet.version>1.6.0rc3</parquet.version>
+		                <chill.version>0.5.0</chill.version>
+                                <ivy.version>2.4.0</ivy.version>
+                                <oro.version>2.0.8</oro.version>
+                                <avro.mapred.classifier></avro.mapred.classifier>
+                                <codahale.metrics.version>3.1.0</codahale.metrics.version>
+                                <commons.httpclient.version>4.2.6</commons.httpclient.version>
+                                <commons.math3.version>3.1.1</commons.math3.version>
+                                <io.netty.version>4.0.23.Final</io.netty.version>
+                                <codehaus.jackson.version>1.8.8</codehaus.jackson.version>
+                                <fasterxml.jackson.version>2.4.4</fasterxml.jackson.version>
+                                <snappy.version>1.1.1.6</snappy.version>
                         </properties>
                 </profile>
 

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -397,17 +397,19 @@ public class SparkInterpreter extends Interpreter {
                  + "_binder.get(\"sc\").asInstanceOf[org.apache.spark.SparkContext]");
     intp.interpret("@transient val sqlc = "
                  + "_binder.get(\"sqlc\").asInstanceOf[org.apache.spark.sql.SQLContext]");
+    intp.interpret("@transient val sqlContext = "
+                 + "_binder.get(\"sqlc\").asInstanceOf[org.apache.spark.sql.SQLContext]");
     intp.interpret("@transient val hiveContext = "
         + "_binder.get(\"hiveContext\").asInstanceOf[org.apache.spark.sql.hive.HiveContext]");
     intp.interpret("import org.apache.spark.SparkContext._");
 
     if (sc.version().startsWith("1.1")) {
-      intp.interpret("import sqlc._");
+      intp.interpret("import sqlContext._");
     } else if (sc.version().startsWith("1.2")) {
-      intp.interpret("import sqlc._");
+      intp.interpret("import sqlContext._");
     } else if (sc.version().startsWith("1.3")) {
-      intp.interpret("import sqlc.implicits._");
-      intp.interpret("import sqlc.sql");
+      intp.interpret("import sqlContext.implicits._");
+      intp.interpret("import sqlContext.sql");
       intp.interpret("import org.apache.spark.sql.functions._");
     }
 

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkInterpreter.java
@@ -142,7 +142,12 @@ public class SparkInterpreter extends Interpreter {
 
   public SQLContext getSQLContext() {
     if (sqlc == null) {
-      sqlc = new SQLContext(getSparkContext());
+      // for spark 1.3x default HiveContext
+      if (getSparkContext().version().startsWith("1.3")) {
+        sqlc = getHiveContext();
+      } else {
+        sqlc = new SQLContext(getSparkContext());
+      }
     }
     return sqlc;
   }

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
@@ -14,7 +14,6 @@ import org.apache.spark.scheduler.Stage;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.SQLContext.QueryExecution;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
-//import org.apache.spark.sql.catalyst.expressions.Row;
 import org.apache.spark.ui.jobs.JobProgressListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,8 +53,6 @@ public class SparkSqlInterpreter extends Interpreter {
         SparkSqlInterpreter.class.getName(),
         new InterpreterPropertyBuilder()
             .add("zeppelin.spark.maxResult", "10000", "Max number of SparkSQL result to display.")
-            .add("zeppelin.spark.useHiveContext", "false",
-                "Use HiveContext instead of SQLContext if it is true.")
             .add("zeppelin.spark.concurrentSQL", "false",
                 "Execute multiple SQL concurrently if set true.")
             .build());
@@ -92,10 +89,6 @@ public class SparkSqlInterpreter extends Interpreter {
     return null;
   }
 
-  private boolean useHiveContext() {
-    return Boolean.parseBoolean(getProperty("zeppelin.spark.useHiveContext"));
-  }
-
   public boolean concurrentSQL() {
     return Boolean.parseBoolean(getProperty("zeppelin.spark.concurrentSQL"));
   }
@@ -108,11 +101,7 @@ public class SparkSqlInterpreter extends Interpreter {
   public InterpreterResult interpret(String st, InterpreterContext context) {
     SQLContext sqlc = null;
 
-    if (useHiveContext()) {
-      sqlc = getSparkInterpreter().getHiveContext();
-    } else {
-      sqlc = getSparkInterpreter().getSQLContext();
-    }
+    sqlc = getSparkInterpreter().getSQLContext();
 
     SparkContext sc = sqlc.sparkContext();
     if (concurrentSQL()) {

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
@@ -129,7 +129,7 @@ public class SparkSqlInterpreter extends Interpreter {
     try {
       rdd = sqlc.sql(st);
 
-      Method take = rdd.getClass().getMethod("take", Integer.class);
+      Method take = rdd.getClass().getMethod("take", int.class);
       rows = (Object[]) take.invoke(rdd, maxResult + 1);
     } catch (Exception e) {
       logger.error("Error", e);
@@ -171,8 +171,8 @@ public class SparkSqlInterpreter extends Interpreter {
     try {
       for (int r = 0; r < maxResult && r < rows.length; r++) {
         Object row = rows[r];
-        Method isNullAt = row.getClass().getMethod("isNullAt", Integer.class);
-        Method apply = row.getClass().getMethod("apply", Integer.class);
+        Method isNullAt = row.getClass().getMethod("isNullAt", int.class);
+        Method apply = row.getClass().getMethod("apply", int.class);
 
         for (int i = 0; i < columns.size(); i++) {
           if (!(Boolean) isNullAt.invoke(row, i)) {

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/SparkSqlInterpreter.java
@@ -225,6 +225,8 @@ public class SparkSqlInterpreter extends Interpreter {
           progressInfo = getProgressFromStage_1_1x(sparkListener, job.finalStage());
         } else if (sc.version().startsWith("1.2")) {
           progressInfo = getProgressFromStage_1_1x(sparkListener, job.finalStage());
+        } else if (sc.version().startsWith("1.3")) {
+          progressInfo = getProgressFromStage_1_1x(sparkListener, job.finalStage());
         } else {
           logger.warn("Spark {} getting progress information not supported" + sc.version());
           continue;

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/ZeppelinContext.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/ZeppelinContext.java
@@ -10,7 +10,6 @@ import java.util.Iterator;
 
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SQLContext;
-import org.apache.spark.sql.SchemaRDD;
 import org.apache.spark.sql.hive.HiveContext;
 
 import scala.Tuple2;
@@ -49,9 +48,11 @@ public class ZeppelinContext {
   public HiveContext hiveContext;
   private GUI gui;
 
+  /* spark-1.3
   public SchemaRDD sql(String sql) {
     return sqlContext.sql(sql);
   }
+  */
 
   /**
    * Load dependency for interpreter and runtime (driver).

--- a/spark/src/main/java/com/nflabs/zeppelin/spark/ZeppelinContext.java
+++ b/spark/src/main/java/com/nflabs/zeppelin/spark/ZeppelinContext.java
@@ -32,12 +32,10 @@ public class ZeppelinContext {
   private InterpreterContext interpreterContext;
 
   public ZeppelinContext(SparkContext sc, SQLContext sql,
-      HiveContext hiveContext,
       InterpreterContext interpreterContext,
       DependencyResolver dep, PrintStream printStream) {
     this.sc = sc;
     this.sqlContext = sql;
-    this.hiveContext = hiveContext;
     this.interpreterContext = interpreterContext;
     this.dep = dep;
     this.out = printStream;

--- a/spark/src/test/java/com/nflabs/zeppelin/spark/SparkSqlInterpreterTest.java
+++ b/spark/src/test/java/com/nflabs/zeppelin/spark/SparkSqlInterpreterTest.java
@@ -62,7 +62,7 @@ public class SparkSqlInterpreterTest {
 		assertEquals("name\tage\nmoon\t33\npark\t34\n", ret.message());
 
 		assertEquals(InterpreterResult.Code.ERROR, sql.interpret("select wrong syntax", context).code());
-		assertEquals(InterpreterResult.Code.ERROR, sql.interpret("select case when name==\"aa\" then name else name end from people", context).code());
+		assertEquals(InterpreterResult.Code.SUCCESS, sql.interpret("select case when name==\"aa\" then name else name end from people", context).code());
 	}
 
 	@Test

--- a/zeppelin-interpreter/src/main/java/com/nflabs/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/com/nflabs/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -25,6 +25,7 @@ import com.nflabs.zeppelin.interpreter.InterpreterContext;
 import com.nflabs.zeppelin.interpreter.InterpreterException;
 import com.nflabs.zeppelin.interpreter.InterpreterGroup;
 import com.nflabs.zeppelin.interpreter.InterpreterResult;
+import com.nflabs.zeppelin.interpreter.LazyOpenInterpreter;
 import com.nflabs.zeppelin.interpreter.thrift.RemoteInterpreterContext;
 import com.nflabs.zeppelin.interpreter.thrift.RemoteInterpreterResult;
 import com.nflabs.zeppelin.interpreter.thrift.RemoteInterpreterService;
@@ -112,7 +113,7 @@ public class RemoteInterpreterServer
       repl.setClassloaderUrls(new URL[]{});
 
       synchronized (interpreterGroup) {
-        interpreterGroup.add(new ClassloaderInterpreter(repl, cl));
+        interpreterGroup.add(new LazyOpenInterpreter((new ClassloaderInterpreter(repl, cl))));
       }
 
       logger.info("Instantiate interpreter {}", className);


### PR DESCRIPTION
Spark 1.3 is released.
This PR make Zeppelin work with Spark 1.3.

* [x] Add profile
* [x] Make Zeppelin build with Spark 1.3
* [x] Take care of SchemaRDD -> DataFrame 
* [x] Test on cluster environment
