### PR TITLE
Fix saveAsParquetFile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,12 @@
 
 			<dependency>
 				<groupId>com.twitter</groupId>
+				<artifactId>parquet-hadoop-bundle</artifactId>
+				<version>${parquet.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.twitter</groupId>
 				<artifactId>chill_${scala.binary.version}</artifactId>
 				<version>${chill.version}</version>
 				<exclusions>


### PR DESCRIPTION
on Spark1.2.1 (and Spark 1.3.0), saveAsParquetFile raise following exception
```
case class Data(n: Int, s: String)
val data = sc.parallelize(Seq(Data(1, "a"), Data(2, "b")))
data.saveAsParquetFile("/tmp/data.parquet")

java.lang.NoSuchFieldError: DECIMAL
	at parquet.schema.Types$PrimitiveBuilder.decimalMetadata(Types.java:389)
	at parquet.schema.Types$PrimitiveBuilder.build(Types.java:306)
	at parquet.schema.Types$PrimitiveBuilder.build(Types.java:232)
	at parquet.schema.Types$Builder.named(Types.java:210)
	at org.apache.spark.sql.parquet.ParquetTypesConverter$$anonfun$fromDataType$1.apply(ParquetTypes.scala:290)
	at org.apache.spark.sql.parquet.ParquetTypesConverter$$anonfun$fromDataType$1.apply(ParquetTypes.scala:281)
	at scala.Option.map(Option.scala:145)
	at org.apache.spark.sql.parquet.ParquetTypesConverter$.fromDataType(ParquetTypes.scala:281)
	at org.apache.spark.sql.parquet.ParquetTypesConverter$$anonfun$4.apply(ParquetTypes.scala:363)
	at org.apache.spark.sql.parquet.ParquetTypesConverter$$anonfun$4.apply(ParquetTypes.scala:362)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
	at scala.collection.immutable.List.foreach(List.scala:318)
	at scala.collection.TraversableLike$class.map(TraversableLike.scala:244)
	at scala.collection.AbstractTraversable.map(Traversable.scala:105)
	at org.apache.spark.sql.parquet.ParquetTypesConverter$.convertFromAttributes(ParquetTypes.scala:361)
	at org.apache.spark.sql.parquet.ParquetTypesConverter$.writeMetaData(ParquetTypes.scala:407)
	at org.apache.spark.sql.parquet.ParquetRelation$.createEmpty(ParquetRelation.scala:168)
	at org.apache.spark.sql.parquet.ParquetRelation$.create(ParquetRelation.scala:147)
	at org.apache.spark.sql.execution.SparkStrategies$ParquetOperations$.apply(SparkStrategies.scala:204)
	at org.apache.spark.sql.catalyst.planning.QueryPlanner$$anonfun$1.apply(QueryPlanner.scala:58)
	at org.apache.spark.sql.catalyst.planning.QueryPlanner$$anonfun$1.apply(QueryPlanner.scala:58)
	at scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:371)
	at org.apache.spark.sql.catalyst.planning.QueryPlanner.apply(QueryPlanner.scala:59)
	at org.apache.spark.sql.SQLContext$QueryExecution.sparkPlan$lzycompute(SQLContext.scala:418)
	at org.apache.spark.sql.SQLContext$QueryExecution.sparkPlan(SQLContext.scala:416)
	at org.apache.spark.sql.SQLContext$QueryExecution.executedPlan$lzycompute(SQLContext.scala:422)
	at org.apache.spark.sql.SQLContext$QueryExecution.executedPlan(SQLContext.scala:422)
	at org.apache.spark.sql.SQLContext$QueryExecution.toRdd$lzycompute(SQLContext.scala:425)
	at org.apache.spark.sql.SQLContext$QueryExecution.toRdd(SQLContext.scala:425)
	at org.apache.spark.sql.SchemaRDDLike$class.saveAsParquetFile(SchemaRDDLike.scala:76)
	at org.apache.spark.sql.SchemaRDD.saveAsParquetFile(SchemaRDD.scala:108)
	at $iwC$$iwC$$iwC$$iwC$$iwC$$iwC.<init>(<console>:24)
```

Problem is 'spark-hive' artifact has transitive dependency 'com.twitter:parquet-hadoop-bundle:jar:1.3.2' and it is conflicting with 'com.twitter:parquet-column:jar:1.6.0rc3'.
This PR make com.twitter:parquet-hadoop-bundle:jar version same to 'com.twitter:parquet-column:jar'.

Ready to be merged.