### PR TITLE
add some features of DataTables plugin (including Excel export)

### DIFF
--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -318,6 +318,16 @@ module.exports = function (grunt) {
           cwd: 'bower_components/jquery-ui/themes/base/images',
           src: '{,*/}*.{png,jpg,jpeg,gif}',
           dest: '<%= yeoman.dist %>/styles/images'
+        }, {
+          expand: true,
+          cwd: 'bower_components/datatables/media/images',
+          src: '{,*/}*.{png,jpg,jpeg,gif}',
+          dest: '<%= yeoman.dist %>/images'
+        }, {
+          expand: true,
+          cwd: 'bower_components/datatables-tabletools/swf',
+          src: '{,*/}*.swf',
+          dest: '<%= yeoman.dist %>/images'
         }]
       },
       styles: {

--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -766,10 +766,15 @@ angular.module('zeppelinWebApp')
 
       // use datatables
       $('#p'+$scope.paragraph.id+'_table .table').DataTable( {
-        dom: 'T<"clear">lfrtip',
+        dom: 'Tt',
         tableTools: {
-            "sSwfPath": "images/copy_csv_xls.swf"
-        }
+            "sSwfPath": "images/copy_csv_xls.swf",
+            "aButtons": [ "csv", "xls" ]
+        },
+        lengthChange: false,
+        searching: false,
+        ordering:  false,
+	paging: false
       });
     };
 

--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -769,7 +769,7 @@ angular.module('zeppelinWebApp')
         dom: 'Tt',
         tableTools: {
             "sSwfPath": "images/copy_csv_xls_pdf.swf",
-            "aButtons": [ "copy", "xls", "pdf" ]
+            "aButtons": [ "csv", "pdf" ]
         },
         lengthChange: false,
         searching: false,

--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -768,8 +768,8 @@ angular.module('zeppelinWebApp')
       $('#p'+$scope.paragraph.id+'_table .table').DataTable( {
         dom: 'Tt',
         tableTools: {
-            "sSwfPath": "images/copy_csv_xls.swf",
-            "aButtons": [ "csv", "xls" ]
+            "sSwfPath": "images/copy_csv_xls_pdf.swf",
+            "aButtons": [ "copy", "xls", "pdf" ]
         },
         lengthChange: false,
         searching: false,

--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -763,6 +763,14 @@ angular.module('zeppelinWebApp')
       // set table height
       var height = $scope.paragraph.config.graph.height;
       $('#p'+$scope.paragraph.id+'_table').height(height);
+
+      // use datatables
+      $('#p'+$scope.paragraph.id+'_table .table').DataTable( {
+        dom: 'T<"clear">lfrtip',
+        tableTools: {
+            "sSwfPath": "images/copy_csv_xls.swf"
+        }
+      });
     };
 
     var retryRenderer = function() {

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -22,7 +22,9 @@
     "ng-sortable": "~1.1.9",
     "angular-elastic": "~2.4.2",
     "angular-elastic-input": "~2.0.1",
-    "angular-xeditable" : "0.1.8"
+    "angular-xeditable": "0.1.8",
+    "datatables": "~1.10.5",
+    "datatables-tabletools": "~2.2.3"
   },
   "devDependencies": {
     "angular-mocks": "1.3.8",
@@ -34,12 +36,14 @@
   },
   "overrides": {
     "ace-builds": {
-        "main": ["src-noconflict/ace.js",
-                 "src-noconflict/mode-scala.js",
-                 "src-noconflict/mode-sql.js",
-                 "src-noconflict/mode-markdown.js",
-                 "src-noconflict/keybinding-emacs.js",
-                 "src-noconflict/ext-language_tools.js"],
+      "main": [
+        "src-noconflict/ace.js",
+        "src-noconflict/mode-scala.js",
+        "src-noconflict/mode-sql.js",
+        "src-noconflict/mode-markdown.js",
+        "src-noconflict/keybinding-emacs.js",
+        "src-noconflict/ext-language_tools.js"
+      ],
       "version": "1.1.8",
       "name": "ace-builds"
     }

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -22,7 +22,7 @@
     "ng-sortable": "~1.1.9",
     "angular-elastic": "~2.4.2",
     "angular-elastic-input": "~2.0.1",
-    "angular-xeditable": "0.1.8",
+    "angular-xeditable" : "0.1.8",
     "datatables": "~1.10.5",
     "datatables-tabletools": "~2.2.3"
   },
@@ -36,14 +36,12 @@
   },
   "overrides": {
     "ace-builds": {
-      "main": [
-        "src-noconflict/ace.js",
-        "src-noconflict/mode-scala.js",
-        "src-noconflict/mode-sql.js",
-        "src-noconflict/mode-markdown.js",
-        "src-noconflict/keybinding-emacs.js",
-        "src-noconflict/ext-language_tools.js"
-      ],
+        "main": ["src-noconflict/ace.js",
+                 "src-noconflict/mode-scala.js",
+                 "src-noconflict/mode-sql.js",
+                 "src-noconflict/mode-markdown.js",
+                 "src-noconflict/keybinding-emacs.js",
+                 "src-noconflict/ext-language_tools.js"],
       "version": "1.1.8",
       "name": "ace-builds"
     }


### PR DESCRIPTION
Hi. I'm Hyokyun Park.

I needed to download HTML tables on the notebook to my local PC.
So I applied the jquery plugin DataTables (available under the MIT license) to zeppelin-web.
https://www.datatables.net/
I used TableTools extension which is a plug-in for the DataTables for Excel-export feature.

DataTables has most features Sorting(ordering), searcing, paging etc goodness, as shown below.

![a](https://cloud.githubusercontent.com/assets/4284478/6797207/6af54fbe-d242-11e4-8da9-655c7fa5dcd2.png)

I want to contribute to this project.
Review and comment, please.
