### PR TITLE
Add link to ApacheCon 2016 followup blog post

### DIFF
--- a/_posts/article/2016-05-31-apache-zeppelin-at-apachecon-bigdata-north-america-2016.md
+++ b/_posts/article/2016-05-31-apache-zeppelin-at-apachecon-bigdata-north-america-2016.md
@@ -1,0 +1,12 @@
+---
+layout: post
+category: article
+title: "Zeppelin at ApacheCon BigData North America 2016"
+description: ""
+tags: [zeppelin, ApacheCon, 2016]
+---
+{% include JB/setup %}
+
+<a href="https://medium.com/@seoul_engineer/apache-zeppelin-at-apachecon-bigdata-north-america-2016-4e15e7b8a155#.9e2yv4fc5" target="_blank">Apache Zeppelin at ApacheCon BigData North America 2016</a>
+
+A small followup on Zeppelin project taking part in ApacheCon in Vancouver.


### PR DESCRIPTION
Linking https://medium.com/@seoul_engineer/apache-zeppelin-at-apachecon-bigdata-north-america-2016-4e15e7b8a155#.9e2yv4fc5 in.
